### PR TITLE
[LC-44] add websocket route for node dispatcher

### DIFF
--- a/iconrpcserver/dispatcher/default/node.py
+++ b/iconrpcserver/dispatcher/default/node.py
@@ -47,43 +47,31 @@ class NodeDispatcher:
         return response.json(dispatch_response, status=dispatch_response.http_status)
 
     @staticmethod
+    async def websocket_dispatch(request, ws, channel_name=None):
+        request = json.loads(await ws.recv())
+        channel_stub = get_channel_stub_by_channel_name(channel_name)
+        approved = await channel_stub.async_task().register_subscriber(remote_address=ws.remote_address)
+
+        if not approved:
+            message = {'error': 'This peer can no longer take more subscribe requests.'}
+            return await ws.send(json.dumps(message))
+
+        try:
+            height = request.get('height')
+            while True:
+                new_block_json = await channel_stub.async_task().announce_new_block(subscriber_block_height=height)
+                await ws.send(new_block_json)
+                height += 1
+        finally:
+            await channel_stub.async_task().unregister_subscriber(remote_address=ws.remote_address)
+
+    @staticmethod
     @methods.add
     async def node_GetChannelInfos(**kwargs):
         channel_infos = await StubCollection().peer_stub.async_task().get_channel_infos()
 
         channel_infos = {"channel_infos": channel_infos}
         return channel_infos
-
-    @staticmethod
-    @methods.add
-    async def node_Subscribe(**kwargs):
-        try:
-            channel = kwargs['context']['channel']
-            del kwargs['context']
-            channel = channel if channel is not None else kwargs['channel']
-        except KeyError:
-            channel = kwargs['channel']
-
-        peer_target = kwargs['peer_target']
-        channel_stub = get_channel_stub_by_channel_name(channel)
-        response_code = await channel_stub.async_task().add_audience_subscriber(peer_target=peer_target)
-        return {"response_code": response_code,
-                "message": message_code.get_response_msg(response_code)}
-
-    @staticmethod
-    @methods.add
-    async def node_Unsubscribe(**kwargs):
-        try:
-            channel = kwargs['context']['channel']
-            del kwargs['context']
-            channel = channel if channel is not None else kwargs['channel']
-        except KeyError:
-            channel = kwargs['channel']
-        peer_target = kwargs['peer_target']
-        channel_stub = get_channel_stub_by_channel_name(channel)
-        response_code = await channel_stub.async_task().remove_audience_subscriber(peer_target=peer_target)
-        return {"response_code": response_code,
-                "message": message_code.get_response_msg(response_code)}
 
     @staticmethod
     @methods.add

--- a/iconrpcserver/server/rest_server.py
+++ b/iconrpcserver/server/rest_server.py
@@ -96,6 +96,9 @@ class ServerComponents(metaclass=SingletonMetaClass):
         self.__app.add_route(Status.as_view(), '/api/v1/status/peer')
         self.__app.add_route(Avail.as_view(), '/api/v1/avail/peer')
 
+        self.__app.add_websocket_route(NodeDispatcher.websocket_dispatch, '/api/node/<channel_name>',
+                                       strict_slashes=False)
+
     def ready(self):
         StubCollection().amqp_target = ServerComponents.conf[ConfigKey.AMQP_TARGET]
         StubCollection().amqp_key = ServerComponents.conf[ConfigKey.AMQP_KEY]

--- a/iconrpcserver/server/rest_server.py
+++ b/iconrpcserver/server/rest_server.py
@@ -83,21 +83,20 @@ class ServerComponents(metaclass=SingletonMetaClass):
 
     def set_resource(self):
         self.__app.add_route(NodeDispatcher.dispatch, '/api/node/<channel_name>', methods=['POST'])
-        self.__app.add_route(NodeDispatcher.dispatch, '/api/node/', methods=['POST'], strict_slashes=False)
+        self.__app.add_route(NodeDispatcher.dispatch, '/api/node/', methods=['POST'])
 
         self.__app.add_route(Version2Dispatcher.dispatch, '/api/v2', methods=['POST'])
         self.__app.add_route(Version3Dispatcher.dispatch, '/api/v3/<channel_name>', methods=['POST'])
-        self.__app.add_route(Version3Dispatcher.dispatch, '/api/v3/', methods=['POST'], strict_slashes=False)
+        self.__app.add_route(Version3Dispatcher.dispatch, '/api/v3/', methods=['POST'])
 
         self.__app.add_route(Version3DebugDispatcher.dispatch, '/api/debug/v3/<channel_name>', methods=['POST'])
-        self.__app.add_route(Version3DebugDispatcher.dispatch, '/api/debug/v3/', methods=['POST'], strict_slashes=False)
+        self.__app.add_route(Version3DebugDispatcher.dispatch, '/api/debug/v3/', methods=['POST'])
 
         self.__app.add_route(Disable.as_view(), '/api/v1', methods=['POST', 'GET'])
         self.__app.add_route(Status.as_view(), '/api/v1/status/peer')
         self.__app.add_route(Avail.as_view(), '/api/v1/avail/peer')
 
-        self.__app.add_websocket_route(NodeDispatcher.websocket_dispatch, '/api/node/<channel_name>',
-                                       strict_slashes=False)
+        self.__app.add_websocket_route(NodeDispatcher.websocket_dispatch, '/api/node/<channel_name>')
 
     def ready(self):
         StubCollection().amqp_target = ServerComponents.conf[ConfigKey.AMQP_TARGET]

--- a/iconrpcserver/utils/message_queue/channel_inner_stub.py
+++ b/iconrpcserver/utils/message_queue/channel_inner_stub.py
@@ -46,15 +46,19 @@ class ChannelInnerTask:
         pass
 
     @message_queue_task
-    async def add_audience_subscriber(self, peer_target):
-        pass
-
-    @message_queue_task
-    async def remove_audience_subscriber(self, peer_target):
-        pass
-
-    @message_queue_task
     async def announce_confirmed_block(self, serialized_block, commit_state):
+        pass
+
+    @message_queue_task
+    async def announce_new_block(self, subscriber_block_height: int):
+        pass
+
+    @message_queue_task
+    async def register_subscriber(self, remote_address):
+        pass
+
+    @message_queue_task
+    async def unregister_subscriber(self, remote_address):
         pass
 
 


### PR DESCRIPTION
## Add websocket connection between citizen node and mother peer

* How it works
  * The websocket connection replaces the existing `node_Subscribe` and `node_AnnounceConfirmedBlock`.
  * After the block height sync of the Citizen node is over, Citizen sends a subscribe request to the websocket, bypassing its current block height. (loopchain side)
  * **This request is received from the icon-rpc-server dispatcher of the mother peer, and it passes the block data whenever a new block is generated.** (update from this branch)

* For compatibility, the existing jsonrpc functions remain for some time.