### PR TITLE
Improve JSON schema validator error message

### DIFF
--- a/iconrpcserver/dispatcher/validator.py
+++ b/iconrpcserver/dispatcher/validator.py
@@ -82,7 +82,7 @@ icx_getBalance_v2: dict = {
         "params": {
             "type": "object",
             "properties": {
-                "address": {"type": "string"},
+                "address": {"type": "string", "format": "address"},
             },
             "additionalProperties": False,
             "required": ["address"]
@@ -286,7 +286,7 @@ icx_getBalance_v3: dict = {
         "params": {
             "type": "object",
             "properties": {
-                "address": {"type": "string"}
+                "address": {"type": "string", "format": "address"}
             },
             "additionalProperties": False,
             "required": ["address"]
@@ -564,8 +564,19 @@ def validate_jsonschema(request: object, schemas: dict = SCHEMA_V3):
     try:
         validator.validate(request)
     except ValidationError as e:
+        print(f"{e.schema_path}, || {e.path}")
+        if e.schema_path[-1] == "additionalProperties":
+            if len(e.path) == 0:
+                message = f"There is an invalid key in 1st depth"
+            else:
+                message = f"There is an invalid key in '{e.path[-1]}'"
+        elif len(e.path) > 0:
+            message = f"'{e.path[-1]}' has an invalid value"
+        else:
+            message = f"Invalid request"
+
         raise GenericJsonRpcServerError(code=JsonError.INVALID_PARAMS,
-                                        message=f"JSON schema validation error: {e.message}",
+                                        message=f"JSON schema validation error: {message}",
                                         http_status=status.HTTP_BAD_REQUEST)
 
 

--- a/iconrpcserver/dispatcher/validator.py
+++ b/iconrpcserver/dispatcher/validator.py
@@ -564,7 +564,6 @@ def validate_jsonschema(request: object, schemas: dict = SCHEMA_V3):
     try:
         validator.validate(request)
     except ValidationError as e:
-        print(f"{e.schema_path}, || {e.path}")
         if e.schema_path[-1] == "additionalProperties":
             if len(e.path) == 0:
                 message = f"There is an invalid key in 1st depth"
@@ -573,7 +572,7 @@ def validate_jsonschema(request: object, schemas: dict = SCHEMA_V3):
         elif len(e.path) > 0:
             message = f"'{e.path[-1]}' has an invalid value"
         else:
-            message = f"Invalid request"
+            message = f"Invalid params"
 
         raise GenericJsonRpcServerError(code=JsonError.INVALID_PARAMS,
                                         message=f"JSON schema validation error: {message}",


### PR DESCRIPTION
 - If request contains an invalid value, the error message will contain key of invalid value
```json
{
    "jsonrpc": "2.0",
    "method": "icx_getBalance",
    "id": 1234,
    "params": {
        "address": "invalid_address"
    }
}
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32602,
        "message": "JSON schema validation error: 'address' has an invalid value"
    },
    "id": 1234
}
```
 - If request contains an invalid key, the error message will contain "invalid key" string only
```json
{
    "jsonrpc": "2.0",
    "method": "icx_getBalance",
    "id": 1234,
    "params": {
        "invalid_key": "hxe611f13bf72f77abad34e7305bcb87d5c30693a1"
    }
}
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32602,
        "message": "JSON schema validation error: There is an invalid key in 'params'"
    },
    "id": 1234
}
```