### PR TITLE
[LC-285] fix port type in cli argument

### DIFF
--- a/iconrpcserver/icon_rpcserver_cli.py
+++ b/iconrpcserver/icon_rpcserver_cli.py
@@ -57,7 +57,7 @@ def main():
                         choices=['start', 'stop'],
                         help='rest type [start|stop]')
 
-    parser.add_argument("-p", type=str, dest=ConfigKey.PORT, default=None,
+    parser.add_argument("-p", type=int, dest=ConfigKey.PORT, default=None,
                         help="rest_proxy port")
     parser.add_argument("-c", type=str, dest=ConfigKey.CONFIG, default=None,
                         help="json configure file path")


### PR DESCRIPTION
fixed the type of port when parsing argument in icon_rpcserver_cli. (since this configure is checked whether it's integer or not when starting process.)