### PR TITLE
[LC-310] upgrade sanic for python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 jsonschema==2.6.0
 requests==2.20.0
 jsonrpcserver==3.5.6
-sanic==0.8.3
+sanic==0.8.3; python_version < '3.7'
+sanic==18.12.0; python_version >= '3.7'
 gunicorn==19.9.0
 grpcio==1.19.0; python_version >= '3.7'
 grpcio-tools==1.19.0; python_version >= '3.7'

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ from setuptools import setup, find_packages
 version = os.environ.get('VERSION')
 
 if version is None:
-	with open(os.path.join('.', 'VERSION')) as version_file:
-		version = version_file.read().strip()
+    with open(os.path.join('.', 'VERSION')) as version_file:
+        version = version_file.read().strip()
 
 with open('requirements.txt') as requirements:
     requires = list(requirements)


### PR DESCRIPTION
 - websockets 6.0 added compatibility with python 3.7
   and sanic 18.12.0 required websockets 6.0