### PR TITLE
[LC-328] add try and finally when ws_subscribe ends

### DIFF
--- a/iconrpcserver/dispatcher/default/websocket.py
+++ b/iconrpcserver/dispatcher/default/websocket.py
@@ -58,8 +58,10 @@ class WSDispatcher:
             WSDispatcher.publish_new_block(ws, channel_name, height)
         ]
 
-        await asyncio.wait(futures, return_when=asyncio.FIRST_EXCEPTION)
-        await WSDispatcher.channel_unregister(ws, channel_name, peer_id)
+        try:
+            await asyncio.wait(futures, return_when=asyncio.FIRST_EXCEPTION)
+        finally:
+            await WSDispatcher.channel_unregister(ws, channel_name, peer_id)
 
     @staticmethod
     async def channel_register(ws, channel_name: str, peer_id: str):


### PR DESCRIPTION
add try/finally to handle websocket connection error and unregister when ws_subscribe ends in python 3.7.2.