### PR TITLE
[LC-351] Edit Avail api

### DIFF
--- a/iconrpcserver/server/rest_server.py
+++ b/iconrpcserver/server/rest_server.py
@@ -155,7 +155,7 @@ class Avail(HTTPMethodView):
         status = HTTPStatus.OK
         result = PeerServiceStub().get_status(channel_name)
 
-        if result['status'] != "Service is online: 0":
+        if not result['service_available']:
             status = HTTPStatus.SERVICE_UNAVAILABLE
 
         return response.json(result, status=status)


### PR DESCRIPTION
**[Please update loopchain first, not only icon-rpc-server](https://github.com/icon-project/loopchain/pull/191#issue-279334512)**

- 'api/v1/avail/peer' responses 200 when the channel state machine has one of states below
     ["BlockGenerate", "Vote", "LeaderComplain", "Watch"]