### PR TITLE
[LC-356] refactor websocket dispatcher

### DIFF
--- a/iconrpcserver/dispatcher/default/websocket.py
+++ b/iconrpcserver/dispatcher/default/websocket.py
@@ -13,14 +13,17 @@
 # limitations under the License.'
 
 import asyncio
+import contextlib
 import json
 import traceback
+from websockets import exceptions
 
 from iconcommons.logger import Logger
 from jsonrpcclient.request import Request
 from jsonrpcserver.aio import AsyncMethods
 
 from iconrpcserver.default_conf.icon_rpcserver_constant import ConfigKey
+from iconrpcserver.protos import message_code
 from iconrpcserver.utils.json_rpc import get_channel_stub_by_channel_name
 from iconrpcserver.utils.message_queue.stub_collection import StubCollection
 from iconrpcserver.utils import get_now_timestamp
@@ -53,91 +56,95 @@ class WSDispatcher:
         height = kwargs['height']
         peer_id = kwargs['peer_id']
 
-        await WSDispatcher.channel_register(ws, channel_name, peer_id, remote_target)
+        async with WSDispatcher.reception(channel_name, peer_id, remote_target) as registered:
+            if not registered:
+                await WSDispatcher.send_and_raise_exception(ws=ws,
+                                                            method="node_ws_PublishHeartbeat",
+                                                            exception=RuntimeError("Unregistered"),
+                                                            error_code=message_code.Response.fail_subscribe_limit)
 
-        futures = [
-            WSDispatcher.publish_heartbeat(ws, channel_name, peer_id),
-            WSDispatcher.publish_new_block(ws, channel_name, height)
-        ]
+            futures = [
+                WSDispatcher.publish_heartbeat(ws),
+                WSDispatcher.publish_new_block(ws, channel_name, height)
+            ]
 
-        try:
             await asyncio.wait(futures, return_when=asyncio.FIRST_EXCEPTION)
-        finally:
-            await WSDispatcher.channel_unregister(ws, channel_name, peer_id)
 
     @staticmethod
-    async def channel_register(ws, channel_name: str, peer_id: str, remote_target: str):
+    @contextlib.asynccontextmanager
+    async def reception(channel_name: str, peer_id: str, remote_target: str):
         channel_stub = get_channel_stub_by_channel_name(channel_name)
         connected_time = get_now_timestamp()
-        approved = await channel_stub.async_task().register_citizen(
+        registered = await channel_stub.async_task().register_citizen(
             peer_id=peer_id,
             target=remote_target,
             connected_time=connected_time
         )
 
-        if not approved:
-            raise RuntimeError("This peer can no longer take more subscribe requests.")
+        if registered:
+            Logger.debug(f"register citizen: {peer_id}")
+        else:
+            Logger.warning(f"This peer can no longer take more subscribe requests.")
 
-        Logger.debug(f"register citizen: {peer_id}")
+        try:
+            yield registered
+        finally:
+            if registered:
+                Logger.debug(f"unregister citizen: {peer_id}")
+                await channel_stub.async_task().unregister_citizen(peer_id=peer_id)
 
     @staticmethod
-    async def channel_unregister(ws, channel_name: str, peer_id: str):
-        channel_stub = get_channel_stub_by_channel_name(channel_name)
-        await channel_stub.async_task().unregister_citizen(peer_id=peer_id)
+    async def publish_heartbeat(ws):
+        exception = None
+        while ws.open:
+            try:
+                request = Request("node_ws_PublishHeartbeat")
+                Logger.debug(f"node_ws_PublishHeartbeat: {request}")
+                await ws.send(json.dumps(request))
+                heartbeat_time = StubCollection().conf[ConfigKey.WS_HEARTBEAT_TIME]
+                await asyncio.sleep(heartbeat_time)
+            except Exception as e:
+                exception = e
+                traceback.print_exc()
+                break
 
-        Logger.debug(f"unregister citizen: {peer_id}")
+        if not exception:
+            exception = ConnectionError("Connection closed.")
 
-    @staticmethod
-    async def publish_heartbeat(ws, channel_name, peer_id):
-        async def _publish_heartbeat():
-            channel_stub = get_channel_stub_by_channel_name(channel_name)
-            exception = None
-            while ws.open:
-                try:
-                    is_registered = await channel_stub.async_task().is_citizen_registered(peer_id=peer_id)
-                    if is_registered:
-                        request = Request("node_ws_PublishHeartbeat")
-                        await ws.send(json.dumps(request))
-                        heartbeat_time = StubCollection().conf[ConfigKey.WS_HEARTBEAT_TIME]
-                        await asyncio.sleep(heartbeat_time)
-                        continue
-
-                    raise RuntimeError("Unregistered")
-
-                except Exception as e:
-                    exception = e
-                    traceback.print_exc()
-                    break
-
-            if not exception:
-                exception = ConnectionError("Connection closed.")
-
-            request = Request("node_ws_PublishHeartbeat",
-                              error=str(exception))
-            await ws.send(json.dumps(request))
-            raise exception
-
-        await asyncio.ensure_future(_publish_heartbeat())
+        error_code = message_code.Response.fail_connection_closed
+        await WSDispatcher.send_and_raise_exception(ws, "node_ws_PublishHeartbeat", exception, error_code)
 
     @staticmethod
     async def publish_new_block(ws, channel_name, height):
-        async def _publish_new_block():
-            nonlocal height
+        exception = None
+        error_code = None
+        channel_stub = get_channel_stub_by_channel_name(channel_name)
+        try:
+            while ws.open:
+                new_block_dumped, confirm_info_bytes = await \
+                    channel_stub.async_task().announce_new_block(subscriber_block_height=height)
+                new_block: dict = json.loads(new_block_dumped)
+                confirm_info = confirm_info_bytes.decode('utf-8')
+                request = Request("node_ws_PublishNewBlock", block=new_block, confirm_info=confirm_info)
+                Logger.debug(f"node_ws_PublishNewBlock: {request}")
 
-            channel_stub = get_channel_stub_by_channel_name(channel_name)
-            try:
-                while ws.open:
-                    new_block_dumped, confirm_info_bytes = await \
-                        channel_stub.async_task().announce_new_block(subscriber_block_height=height)
-                    new_block: dict = json.loads(new_block_dumped)
-                    confirm_info = confirm_info_bytes.decode('utf-8')
-                    request = Request("node_ws_PublishNewBlock", block=new_block, confirm_info=confirm_info)
-                    Logger.debug(f"node_ws_PublishNewBlock: {request}")
+                await ws.send(json.dumps(request))
+                height += 1
+        except exceptions.ConnectionClosed as e:
+            exception = e
+            error_code = message_code.Response.fail_connection_closed
+        except Exception as e:
+            exception = e
+            error_code = message_code.Response.fail_announce_block
+            traceback.print_exc()
 
-                    await ws.send(json.dumps(request))
-                    height += 1
-            except Exception as e:
-                traceback.print_exc()
-                raise e
+        if not exception:
+            exception = ConnectionError("Connection closed.")
 
-        await asyncio.ensure_future(_publish_new_block())
+        await WSDispatcher.send_and_raise_exception(ws, "node_ws_PublishNewBlock", exception, error_code)
+
+    @staticmethod
+    async def send_and_raise_exception(ws, method, exception, error_code):
+        request = Request(method, error=str(exception), code=error_code)
+        await ws.send(json.dumps(request))
+        raise exception

--- a/iconrpcserver/protos/message_code.py
+++ b/iconrpcserver/protos/message_code.py
@@ -74,6 +74,7 @@ class Response:
     fail_wrong_block_height = -17
     fail_no_permission = -18
     fail_out_of_tps_limit = -19
+    fail_connection_closed = -20
     fail_tx_invalid_unknown = -100
     fail_tx_invalid_hash_format = -101
     fail_tx_invalid_hash_generation = -102


### PR DESCRIPTION
- remove raise RuntimeError, in order to send first heartbeat with "Unregistered" error when subscription limit is over.