### PR TITLE
 [LC-392] remove channel_name param in get node info

### DIFF
--- a/iconrpcserver/dispatcher/v3/icx.py
+++ b/iconrpcserver/dispatcher/v3/icx.py
@@ -19,15 +19,15 @@ from urllib.parse import urlsplit, urlparse
 from iconcommons.logger import Logger
 from jsonrpcserver import status
 
+from iconrpcserver.default_conf.icon_rpcserver_constant import ConfigKey
 from iconrpcserver.dispatcher import GenericJsonRpcServerError, JsonError
-from iconrpcserver.server.rest_property import RestProperty
-from iconrpcserver.protos import message_code
 from iconrpcserver.dispatcher.v3 import methods
+from iconrpcserver.protos import message_code
+from iconrpcserver.server.rest_property import RestProperty
 from iconrpcserver.utils.icon_service import make_request, response_to_json_query, ParamType, convert_params
-from iconrpcserver.utils.json_rpc import relay_tx_request, get_block_by_params
 from iconrpcserver.utils.json_rpc import get_icon_stub_by_channel_name, get_channel_stub_by_channel_name
+from iconrpcserver.utils.json_rpc import relay_tx_request, get_block_by_params
 from iconrpcserver.utils.message_queue.stub_collection import StubCollection
-from iconrpcserver.default_conf.icon_rpcserver_constant import NodeType, ConfigKey
 
 
 class IcxDispatcher:
@@ -58,8 +58,7 @@ class IcxDispatcher:
 
     @staticmethod
     async def __relay_icx_transaction(url, path, message):
-        relay_target = RestProperty().relay_target
-        relay_target = relay_target if relay_target is not None else RestProperty().rs_target
+        relay_target = RestProperty().relay_target or RestProperty().rs_target
         if not relay_target:
             raise GenericJsonRpcServerError(
                 code=JsonError.INTERNAL_ERROR,

--- a/iconrpcserver/server/rest_server.py
+++ b/iconrpcserver/server/rest_server.py
@@ -121,12 +121,11 @@ class ServerComponents(metaclass=SingletonMetaClass):
             else:
                 await StubCollection().create_peer_stub()
                 channels = await StubCollection().peer_stub.async_task().get_channel_infos()
-                channel_name = None
                 for channel_name in channels:
                     await StubCollection().create_channel_stub(channel_name)
                     await StubCollection().create_channel_tx_creator_stub(channel_name)
                     await StubCollection().create_icon_score_stub(channel_name)
-                results: dict = await StubCollection().peer_stub.async_task().get_channel_info_detail(channel_name)
+                results: dict = await StubCollection().peer_stub.async_task().get_node_info_detail()
                 RestProperty().node_type = NodeType(results.get('node_type'))
                 RestProperty().rs_target = results.get('rs_target')
                 relay_target = StubCollection().conf.get(ConfigKey.RELAY_TARGET, None)

--- a/iconrpcserver/utils/message_queue/peer_inner_stub.py
+++ b/iconrpcserver/utils/message_queue/peer_inner_stub.py
@@ -27,7 +27,7 @@ class PeerInnerTask:
         pass
 
     @message_queue_task
-    async def get_channel_info_detail(self, channel_name) -> dict:
+    async def get_node_info_detail(self) -> dict:
         pass
 
 


### PR DESCRIPTION
This PR should be merged after LC-397 is merged into develop.