### PR TITLE
[LC-367] snapcraft packaging

### DIFF
--- a/iconrpcserver/default_conf/icon_rpcserver_constant.py
+++ b/iconrpcserver/default_conf/icon_rpcserver_constant.py
@@ -69,6 +69,7 @@ class ConfigKey:
     WS_HEARTBEAT_TIME = 'wsHeartBeatTime'
     REQUEST_MAX_SIZE = "requestMaxSize"
     RELAY_TARGET = "relayTarget"
+    GUNICORN_WORKER_TMP_DIR = 'gunicornWorkerTmpDir'
 
 
 ICON_RPC_SERVER_LOG_TAG = 'IconService'

--- a/iconrpcserver/icon_rpcserver_app.py
+++ b/iconrpcserver/icon_rpcserver_app.py
@@ -44,6 +44,11 @@ class StandaloneApplication(gunicorn.app.base.BaseApplication):
         self.application = app
         super(StandaloneApplication, self).__init__()
 
+        # FIXME : below is temporary patch for snap packaging
+        from gunicorn.workers import base
+        from iconrpcserver.utils import gunicorn_patch
+        base.WorkerTmp.__init__ = gunicorn_patch.__worker_tmp_init__
+
     def load_config(self):
         config = dict([(key, value) for key, value in iteritems(self.options)
                        if key in self.cfg.settings and value is not None])
@@ -161,6 +166,10 @@ async def _run(conf: 'IconConfig'):
         'keyfile': keyfile,
         'capture_output': False
     }
+
+    # TODO : update gunicorn settings at once
+    if conf.get(ConfigKey.GUNICORN_WORKER_TMP_DIR, None):
+        options.update({'worker_tmp_dir': conf[ConfigKey.GUNICORN_WORKER_TMP_DIR]})
 
     # Launch gunicorn web server.
     ServerComponents.conf = conf

--- a/iconrpcserver/utils/gunicorn_patch.py
+++ b/iconrpcserver/utils/gunicorn_patch.py
@@ -1,0 +1,35 @@
+
+import os
+import platform
+import tempfile
+
+from gunicorn import util
+
+PLATFORM = platform.system()
+IS_CYGWIN = PLATFORM.startswith('CYGWIN')
+
+
+def __worker_tmp_init__(self, cfg):
+    old_umask = os.umask(cfg.umask)
+    fdir = cfg.worker_tmp_dir
+    if fdir and not os.path.isdir(fdir):
+        raise RuntimeError("%s doesn't exist. Can't create workertmp." % fdir)
+    fd, name = tempfile.mkstemp(prefix="wgunicorn-", dir=fdir)
+
+    # avoid os.chown when running via snap with strict confinement
+    # ref : https://github.com/benoitc/gunicorn/issues/2059
+    if cfg.uid != os.geteuid() or cfg.gid != os.getegid():
+        # allows the process to write to the file
+        util.chown(name, cfg.uid, cfg.gid)
+    os.umask(old_umask)
+
+    # unlink the file so we don't leak tempory files
+    try:
+        if not IS_CYGWIN:
+            util.unlink(name)
+        self._tmp = os.fdopen(fd, 'w+b', 1)
+    except:
+        os.close(fd)
+        raise
+
+    self.spinner = 0


### PR DESCRIPTION
**monkey patch gunicorn `WorkerTmp.__init__` method**

 - prevent os.chown in gunicorn workerTmp when running via snap
 - added gunicorn options : worker_tmp_dir

related gunicorn issue  : https://github.com/benoitc/gunicorn/issues/2059