### PR TITLE
[LC-473] fixed generate-proto fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
 help:
 	@awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][-_[:alnum:]]+:/{print substr($$1,1,index($$1,":")),c}1{c=0}' $(MAKEFILE_LIST) | column -s: -t
 
+SHELL := /bin/bash
+
+PROTO_VENV := proto_venv
+
 # Generate python gRPC proto
 generate-proto:
+	@python3 -m venv ${PROTO_VENV}
+	@source ${PROTO_VENV}/bin/activate && pip3 install -U grpcio==1.20.1 grpcio-tools==1.20.1 protobuf==3.7.0
+
 	@echo "Generating python grpc code from proto into > " `pwd`
-	python3 -m grpc.tools.protoc -I'./iconrpcserver/protos' \
+	@source ${PROTO_VENV}/bin/activate && python3 -m grpc.tools.protoc -I'./iconrpcserver/protos' \
 		--python_out='./iconrpcserver/protos' \
 		--grpc_python_out='./iconrpcserver/protos' \
 		'./iconrpcserver/protos/loopchain.proto'
+	@rm -rf ${PROTO_VENV}
 
 # Run unittest
 test:


### PR DESCRIPTION
 - generate-proto failed when grpc library is not installed
   so, fixed to create venv and install grpc library and generate proto