### PR TITLE
[LC-490] generate proto from python grpc package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This is intended to give an introduction ICON RPC Server. ICON RPC Server receiv
 ## Building source code
  First, clone this project. Then go to the project folder and create a user environment and run build script.
 ```
-$ virtualenv -p python3 venv  # Create a virtual environment.
+$ python3 -m venv venv        # Create a virtual environment.
 $ source venv/bin/activate    # Enter the virtual environment.
-(venv)$ ./build.sh            # run build script
+(venv)$ make build            # run build
 (venv)$ ls dist/              # check result wheel file
-iconrpcserver-1.0.0-py3-none-any.whl
+iconrpcserver-x.x.x-py3-none-any.whl
 ```
 
 ## Installation
@@ -38,6 +38,7 @@ ICON RPC Server development and execution requires following environments.
 ### Setup on MacOS / Linux
 
 ```bash
+$ python3 -m venv work      # Create a virtual environment.
 # Install the ICON RPC Server
 (work) $ pip install iconrpcserver
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import os
-import subprocess
 
 from setuptools import setup, find_packages
 from setuptools.command.build_py import build_py as _build_py
@@ -17,7 +16,18 @@ with open('requirements.txt') as requirements:
 
 
 def generate_proto():
-    subprocess.check_call(['make', 'generate-proto'])
+    import grpc_tools.protoc
+
+    proto_path = './iconrpcserver/protos'
+    proto_file = os.path.join(proto_path, 'loopchain.proto')
+
+    grpc_tools.protoc.main([
+        'grcp_tools.protoc',
+        f'-I{proto_path}',
+        f'--python_out={proto_path}',
+        f'--grpc_python_out={proto_path}',
+        f'{proto_file}'
+    ])
 
 
 class build_py(_build_py):


### PR DESCRIPTION
When you build iconrpcserver wheel, `grpcio, grpcio-tools, protobuf` need to be installed already.
and, you can just `make generate-proto` with github source for develop.

it works now in travis, docker, snapcraft.

related PR : https://github.com/icon-project/loopchain/pull/262