### PR TITLE
[LC-454] support rs_target & relay_target by channel

### DIFF
--- a/iconrpcserver/dispatcher/v2/version2.py
+++ b/iconrpcserver/dispatcher/v2/version2.py
@@ -69,7 +69,7 @@ class Version2Dispatcher:
 
     @staticmethod
     async def __relay_icx_transaction(url, path, message):
-        rs_target = RestProperty().rs_target
+        rs_target = RestProperty().relay_target[ConfigKey.CHANNEL] or RestProperty().rs_target[ConfigKey.CHANNEL]
         if not rs_target:
             response_code = message_code.Response.fail_invalid_peer_target
             return {'response_code': response_code,

--- a/iconrpcserver/dispatcher/v3/icx.py
+++ b/iconrpcserver/dispatcher/v3/icx.py
@@ -60,7 +60,7 @@ class IcxDispatcher:
 
     @staticmethod
     async def __relay_icx_transaction(url, path, message):
-        relay_target = RestProperty().relay_target or RestProperty().rs_target
+        relay_target = RestProperty().relay_target[ConfigKey.CHANNEL] or RestProperty().rs_target[ConfigKey.CHANNEL]
         if not relay_target:
             raise GenericJsonRpcServerError(
                 code=JsonError.INTERNAL_ERROR,

--- a/iconrpcserver/server/rest_property.py
+++ b/iconrpcserver/server/rest_property.py
@@ -17,5 +17,5 @@ from ..components import SingletonMetaClass
 
 class RestProperty(metaclass=SingletonMetaClass):
     def __init__(self):
-        self.rs_target = None
-        self.relay_target = None
+        self.rs_target = dict()
+        self.relay_target = dict()

--- a/iconrpcserver/server/rest_server.py
+++ b/iconrpcserver/server/rest_server.py
@@ -127,6 +127,7 @@ class ServerComponents(metaclass=SingletonMetaClass):
 
                     channel_stub = StubCollection().channel_stubs[channel_name]
                     rs_target = await channel_stub.async_task().get_rs_target()
+                    Logger.debug(f"Radiostation Target from Channel: {rs_target}")
                     RestProperty().rs_target[channel_name] = rs_target
 
                     relay_target = StubCollection().conf.get(ConfigKey.RELAY_TARGET, None)

--- a/iconrpcserver/server/rest_server.py
+++ b/iconrpcserver/server/rest_server.py
@@ -124,13 +124,17 @@ class ServerComponents(metaclass=SingletonMetaClass):
                     await StubCollection().create_channel_stub(channel_name)
                     await StubCollection().create_channel_tx_creator_stub(channel_name)
                     await StubCollection().create_icon_score_stub(channel_name)
-                results: dict = await StubCollection().peer_stub.async_task().get_node_info_detail()
-                RestProperty().rs_target = results.get('rs_target')
-                relay_target = StubCollection().conf.get(ConfigKey.RELAY_TARGET, None)
-                RestProperty().relay_target = urlparse(relay_target).netloc \
-                    if urlparse(relay_target).scheme else relay_target
 
-            Logger.debug(f'rest_server:initialize complete. rs_target({RestProperty().rs_target})')
+                    channel_stub = StubCollection().channel_stubs[channel_name]
+                    rs_target = await channel_stub.async_task().get_rs_target()
+                    RestProperty().rs_target[channel_name] = rs_target
+
+                    relay_target = StubCollection().conf.get(ConfigKey.RELAY_TARGET, None)
+                    relay_target = urlparse(relay_target).netloc if urlparse(relay_target).scheme else relay_target
+                    RestProperty().relay_target[channel_name] = relay_target
+
+            Logger.debug(f'rest_server:initialize complete. rs_target({RestProperty().rs_target}) '
+                         f'relay_target({RestProperty().relay_target})')
 
     def serve(self, api_port):
         self.ready()

--- a/iconrpcserver/utils/message_queue/channel_inner_stub.py
+++ b/iconrpcserver/utils/message_queue/channel_inner_stub.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
 
 class ChannelInnerTask:
     @message_queue_task
+    async def get_rs_target(self) -> str:
+        pass
+
+    @message_queue_task
     async def get_invoke_result(self, tx_hash) -> Tuple[int, str]:
         pass
 


### PR DESCRIPTION
coupled PR: https://github.com/icon-project/loopchain/pull/318

# Changes
- Initialize `rs_target` from `ChannelService`, not `PeerService`