### PR TITLE
[LC-624] Remove `REDIRECT_PROTOCOL` and its followings

### DIFF
--- a/iconrpcserver/default_conf/icon_rpcserver_constant.py
+++ b/iconrpcserver/default_conf/icon_rpcserver_constant.py
@@ -64,7 +64,6 @@ class ConfigKey:
     REST_ADDITIONAL_TIMEOUT = 'restAdditionalTimeout'
     SCORE_QUERY_TIMEOUT = 'scoreQueryTimeout'
     TBEARS_MODE = 'tbearsMode'
-    REDIRECT_PROTOCOL = 'redirectProtocol'
     WS_HEARTBEAT_TIME = 'wsHeartBeatTime'
     REQUEST_MAX_SIZE = 'requestMaxSize'
     GUNICORN_CONFIG = 'gunicornConfig'

--- a/iconrpcserver/dispatcher/v2/version2.py
+++ b/iconrpcserver/dispatcher/v2/version2.py
@@ -27,7 +27,6 @@ from iconrpcserver.default_conf.icon_rpcserver_constant import ConfigKey, ApiVer
 from iconrpcserver.dispatcher import GenericJsonRpcServerError
 from iconrpcserver.dispatcher import validate_jsonschema_v2
 from iconrpcserver.protos import message_code
-from iconrpcserver.utils import get_protocol_from_uri
 from iconrpcserver.utils.icon_service import response_to_json_query, RequestParamType
 from iconrpcserver.utils.icon_service.converter import make_request
 from iconrpcserver.utils.json_rpc import relay_tx_request, get_block_v2_by_params

--- a/iconrpcserver/dispatcher/v2/version2.py
+++ b/iconrpcserver/dispatcher/v2/version2.py
@@ -68,22 +68,14 @@ class Version2Dispatcher:
         return sanic_response.json(response.deserialized(), status=response.http_status, dumps=json.dumps)
 
     @staticmethod
-    async def __relay_icx_transaction(url, path, message, channel_name, relay_target):
+    async def __relay_icx_transaction(path, message, channel_name, relay_target):
         if not relay_target:
             response_code = message_code.Response.fail_invalid_peer_target
             return {'response_code': response_code,
                     'message': message_code.responseCodeMap[response_code][1],
                     'tx_hash': None}
 
-        dispatch_protocol = get_protocol_from_uri(url)
-        Logger.debug(f'Dispatch Protocol: {dispatch_protocol}')
-        redirect_protocol = StubCollection().conf.get(ConfigKey.REDIRECT_PROTOCOL)
-        Logger.debug(f'Redirect Protocol: {redirect_protocol}')
-        if redirect_protocol:
-            dispatch_protocol = redirect_protocol
-        Logger.debug(f'Protocol: {dispatch_protocol}')
-
-        return await relay_tx_request(dispatch_protocol, message, relay_target, path[1:], ApiVersion.v2.name)
+        return await relay_tx_request(relay_target, message, path[1:], ApiVersion.v2.name)
 
     @staticmethod
     @methods.add
@@ -105,7 +97,7 @@ class Version2Dispatcher:
             await channel_tx_creator_stub.async_task().create_icx_tx(kwargs)
 
         if response_code == message_code.Response.fail_no_permission:
-            return await Version2Dispatcher.__relay_icx_transaction(url, path, kwargs, channel, relay_target)
+            return await Version2Dispatcher.__relay_icx_transaction(path, kwargs, channel, relay_target)
 
         response_data = {'response_code': response_code}
         if response_code != message_code.Response.success:

--- a/iconrpcserver/dispatcher/v2/version2.py
+++ b/iconrpcserver/dispatcher/v2/version2.py
@@ -68,7 +68,7 @@ class Version2Dispatcher:
         return sanic_response.json(response.deserialized(), status=response.http_status, dumps=json.dumps)
 
     @staticmethod
-    async def __relay_icx_transaction(path, message, channel_name, relay_target):
+    async def __relay_icx_transaction(path, message, relay_target):
         if not relay_target:
             response_code = message_code.Response.fail_invalid_peer_target
             return {'response_code': response_code,
@@ -97,7 +97,7 @@ class Version2Dispatcher:
             await channel_tx_creator_stub.async_task().create_icx_tx(kwargs)
 
         if response_code == message_code.Response.fail_no_permission:
-            return await Version2Dispatcher.__relay_icx_transaction(path, kwargs, channel, relay_target)
+            return await Version2Dispatcher.__relay_icx_transaction(path, kwargs, relay_target)
 
         response_data = {'response_code': response_code}
         if response_code != message_code.Response.success:

--- a/iconrpcserver/dispatcher/v3/icx.py
+++ b/iconrpcserver/dispatcher/v3/icx.py
@@ -67,7 +67,7 @@ class IcxDispatcher:
         return response_to_json_query(response)
 
     @staticmethod
-    async def __relay_icx_transaction(url, path, message: dict, channel_name, relay_target):
+    async def __relay_icx_transaction(path, message: dict, channel_name, relay_target):
         if not relay_target:
             raise GenericJsonRpcServerError(
                 code=JsonError.INTERNAL_ERROR,
@@ -75,15 +75,7 @@ class IcxDispatcher:
                 http_status=status.HTTP_INTERNAL_ERROR
             )
 
-        dispatch_protocol = get_protocol_from_uri(url)
-        Logger.debug(f'Dispatch Protocol: {dispatch_protocol}')
-        redirect_protocol = StubCollection().conf.get(ConfigKey.REDIRECT_PROTOCOL)
-        Logger.debug(f'Redirect Protocol: {redirect_protocol}')
-        if redirect_protocol:
-            dispatch_protocol = redirect_protocol
-        Logger.debug(f'Protocol: {dispatch_protocol}')
-
-        return await relay_tx_request(dispatch_protocol, message, relay_target, path=path[1:])
+        return await relay_tx_request(relay_target, message, path=path[1:])
 
     @staticmethod
     @methods.add
@@ -106,7 +98,7 @@ class IcxDispatcher:
             await channel_tx_creator_stub.async_task().create_icx_tx(kwargs)
 
         if response_code == message_code.Response.fail_no_permission:
-            return await IcxDispatcher.__relay_icx_transaction(url, path, kwargs, channel, relay_target)
+            return await IcxDispatcher.__relay_icx_transaction(path, kwargs, channel, relay_target)
 
         if response_code != message_code.Response.success:
             raise GenericJsonRpcServerError(

--- a/iconrpcserver/dispatcher/v3/icx.py
+++ b/iconrpcserver/dispatcher/v3/icx.py
@@ -23,7 +23,6 @@ from iconrpcserver.default_conf.icon_rpcserver_constant import ConfigKey
 from iconrpcserver.dispatcher import GenericJsonRpcServerError, JsonError
 from iconrpcserver.dispatcher.v3 import methods
 from iconrpcserver.protos import message_code
-from iconrpcserver.utils import get_protocol_from_uri
 from iconrpcserver.utils.icon_service import (response_to_json_query,
                                               RequestParamType, ResponseParamType)
 from iconrpcserver.utils.icon_service.converter import convert_params, make_request

--- a/iconrpcserver/dispatcher/v3/icx.py
+++ b/iconrpcserver/dispatcher/v3/icx.py
@@ -67,7 +67,7 @@ class IcxDispatcher:
         return response_to_json_query(response)
 
     @staticmethod
-    async def __relay_icx_transaction(path, message: dict, channel_name, relay_target):
+    async def __relay_icx_transaction(path, message: dict, relay_target):
         if not relay_target:
             raise GenericJsonRpcServerError(
                 code=JsonError.INTERNAL_ERROR,
@@ -98,7 +98,7 @@ class IcxDispatcher:
             await channel_tx_creator_stub.async_task().create_icx_tx(kwargs)
 
         if response_code == message_code.Response.fail_no_permission:
-            return await IcxDispatcher.__relay_icx_transaction(path, kwargs, channel, relay_target)
+            return await IcxDispatcher.__relay_icx_transaction(path, kwargs, relay_target)
 
         if response_code != message_code.Response.success:
             raise GenericJsonRpcServerError(

--- a/iconrpcserver/icon_rpcserver_app.py
+++ b/iconrpcserver/icon_rpcserver_app.py
@@ -119,10 +119,6 @@ async def _check_rabbitmq(amqp_target: str):
 
 
 async def _run(conf: 'IconConfig'):
-    redirect_protocol_env = os.getenv(camel_to_upper_snake(ConfigKey.REDIRECT_PROTOCOL))
-    if redirect_protocol_env:
-        conf.update_conf({ConfigKey.REDIRECT_PROTOCOL: redirect_protocol_env})
-
     Logger.print_config(conf, ICON_RPCSERVER_CLI)
 
     # Connect gRPC stub.

--- a/iconrpcserver/utils/__init__.py
+++ b/iconrpcserver/utils/__init__.py
@@ -63,7 +63,3 @@ def convert_upper_camel_method_to_lower_camel(method_name: str) -> str:
 
 def get_now_timestamp():
     return hex(int(time.time() * 1_000_000))
-
-
-def get_protocol_from_uri(uri: str) -> str:
-    return urlsplit(uri).scheme

--- a/iconrpcserver/utils/json_rpc.py
+++ b/iconrpcserver/utils/json_rpc.py
@@ -29,12 +29,9 @@ from ..utils.icon_service.templates import ResponseParamType
 from ..utils.message_queue.stub_collection import StubCollection
 
 
-async def relay_tx_request(protocol, message, relay_target, path, version=ApiVersion.v3.name):
+async def relay_tx_request(relay_target, message, path, version=ApiVersion.v3.name):
     method_name = "icx_sendTransaction"
 
-    # TODO required post review [LC-454]
-    # relay_uri = f"{protocol}://{relay_target}/{path}"
-    # I think relay_target is already normalized by loopchain
     relay_uri = f"{relay_target}/{path}"
     Logger.debug(f'relay_uri: {relay_uri}')
 

--- a/tests/dispatcher/test_dispatcher.py
+++ b/tests/dispatcher/test_dispatcher.py
@@ -1,0 +1,165 @@
+import copy
+
+import pytest
+from mock import MagicMock, AsyncMock
+
+from iconrpcserver.dispatcher.v2 import Version2Dispatcher
+from iconrpcserver.dispatcher.v3.icx import IcxDispatcher
+from iconrpcserver.protos import message_code
+from iconrpcserver.utils.json_rpc import relay_tx_request
+from iconrpcserver.utils.message_queue.channel_inner_stub import ChannelTxCreatorInnerStub, ChannelTxCreatorInnerTask
+from iconrpcserver.utils.message_queue.icon_score_inner_stub import IconScoreInnerStub, IconScoreInnerTask
+from iconrpcserver.utils.message_queue.stub_collection import StubCollection
+
+CHANNEL_NAME = "icon_dex"
+TX_RESULT_HASH = "0x4bf74e6aeeb43bde5dc8d5b62537a33ac8eb7605ebbdb51b015c1881b45b3aed"
+
+
+def create_channel_tx_creator_stub(**kwargs) -> ChannelTxCreatorInnerStub:
+    """Create ChannelTxCreatorStub.
+
+    Note that return value is actually `mock.Mock`.
+    """
+    task: ChannelTxCreatorInnerTask = AsyncMock(ChannelTxCreatorInnerTask)
+    task.create_icx_tx.return_value = [
+        kwargs.get("response_code"),
+        kwargs.get("tx_hash", TX_RESULT_HASH),
+        "relay_target"
+    ]
+
+    stub: ChannelTxCreatorInnerStub = MagicMock(ChannelTxCreatorInnerStub)
+    stub.async_task.return_value = task
+
+    return stub
+
+
+def create_icon_score_stub(**kwargs) -> IconScoreInnerStub:
+    """Create IconScoreInnerStub.
+
+    Note that return value is actually `mock.Mock`.
+    """
+    task: IconScoreInnerTask = AsyncMock(IconScoreInnerTask)
+    task.validate_transaction.return_value = "result"
+
+    stub: IconScoreInnerStub = MagicMock(IconScoreInnerStub)
+    stub.async_task.return_value = task
+
+    return stub
+
+
+@pytest.fixture(autouse=True)
+def mocking_stub_collection():
+    """Setup StubCollection and Teardown it after each test ends."""
+    StubCollection().conf = {
+        "channel": CHANNEL_NAME
+    }
+    StubCollection().icon_score_stubs[CHANNEL_NAME] = create_icon_score_stub()
+
+    yield
+
+    StubCollection().amqp_target = None
+    StubCollection().amqp_key = None
+    StubCollection().conf = None
+
+    StubCollection().peer_stub = None
+    StubCollection().channel_stubs = {}
+    StubCollection().channel_tx_creator_stubs = {}
+    StubCollection().icon_score_stubs = {}
+
+
+class _TestDispatcher:
+    # https://github.com/icon-project/icon-rpc-server/blob/master/docs/icon-json-rpc-v3.md#coin-transfer
+    REQUESTS = {
+        "icx_sendTransaction": {
+            "context": {
+                "url": "https://URL.com",
+                "channel": "icon_dex",
+            },
+            "jsonrpc": "2.0",
+            "method": "icx_sendTransaction",
+            "id": 1234,
+            "params": {
+                "version": "0x3",
+                "from": "hxbe258ceb872e08851f1f59694dac2558708ece11",
+                "to": "hx5bfdb090f43a808005ffc27c25b213145e80b7cd",
+                "value": "0xde0b6b3a7640000",
+                "stepLimit": "0x12345",
+                "timestamp": "0x563a6cf330136",
+                "nid": "0x3",
+                "nonce": "0x1",
+                "signature": "VAia7YZ2Ji6igKWzjR2YsGa2m53nKPrfK7uXYW78QLE+ATehAVZPC40szvAiA6NEU5gCYB4c4qaQzqDh2ugcHgA="
+            }
+        }
+    }
+
+    @pytest.fixture
+    def mock_channel_tx_creator(self):
+        """Setup mocked ChannelTxCreator."""
+        def _(response_code, tx_hash=TX_RESULT_HASH):
+            channel_tx_creator_stub = create_channel_tx_creator_stub(response_code=response_code, tx_hash=tx_hash)
+            StubCollection().channel_tx_creator_stubs[CHANNEL_NAME] = channel_tx_creator_stub
+
+        return _
+
+
+@pytest.mark.asyncio
+class TestDispatcherV2(_TestDispatcher):
+    async def test_icx_sendTransaction(self, mock_channel_tx_creator):
+        # Given I receives icx_sendTransaction request
+        json_request = copy.deepcopy(self.REQUESTS["icx_sendTransaction"])
+        # And the node is a validator
+        mock_channel_tx_creator(response_code=message_code.Response.success)
+
+        # When I call dispatch method
+        json_response: dict = await Version2Dispatcher.icx_sendTransaction(**json_request)
+
+        # Then I should receive response code and tx hash as dict type
+        assert json_response["response_code"] == message_code.Response.success
+        assert json_response["tx_hash"] == TX_RESULT_HASH
+
+    async def test_icx_sendTransaction_must_relay_if_no_permission(self, mock_channel_tx_creator, monkeypatch):
+        # Mocking to check tx is relayed or not!
+        mock_relay_tx_request = AsyncMock()
+        monkeypatch.setattr(f"{Version2Dispatcher.__module__}.{relay_tx_request.__name__}", mock_relay_tx_request)
+
+        # Given I receives icx_sendTransaction request
+        json_request = copy.deepcopy(self.REQUESTS["icx_sendTransaction"])
+        # And the node is not a validator
+        mock_channel_tx_creator(response_code=message_code.Response.fail_no_permission)
+
+        # When I call dispatch method
+        json_response: dict = await Version2Dispatcher.icx_sendTransaction(**json_request)
+
+        # Then the server should relay tx to another node
+        mock_relay_tx_request.assert_called()
+
+
+@pytest.mark.asyncio
+class TestDispatcherV3Icx(_TestDispatcher):
+    async def test_icx_sendTransaction(self, mock_channel_tx_creator):
+        # Given I receives icx_sendTransaction request
+        json_request = copy.deepcopy(self.REQUESTS["icx_sendTransaction"])
+        # And the node is a validator
+        mock_channel_tx_creator(response_code=message_code.Response.success)
+
+        # When I call dispatch method
+        tx_hash: str = await IcxDispatcher.icx_sendTransaction(**json_request)
+
+        # Then I should receive valid tx_hash
+        assert tx_hash.startswith("0x") and len(tx_hash) == 2 + 64
+
+    async def test_icx_sendTransaction_must_relay_if_no_permission(self, mock_channel_tx_creator, monkeypatch):
+        # Mocking to check tx is relayed or not!
+        mock_relay_tx_request = AsyncMock()
+        monkeypatch.setattr(f"{IcxDispatcher.__module__}.{relay_tx_request.__name__}", mock_relay_tx_request)
+
+        # Given I receives icx_sendTransaction request
+        json_request = copy.deepcopy(self.REQUESTS["icx_sendTransaction"])
+        # And the node is a validator
+        mock_channel_tx_creator(response_code=message_code.Response.fail_no_permission)
+
+        # When I call dispatch method
+        tx_hash: str = await IcxDispatcher.icx_sendTransaction(**json_request)
+
+        # Then the server should relay tx to another node
+        mock_relay_tx_request.assert_called()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+import pytest
+from jsonrpcclient.response import Response, SuccessResponse
+
+from mock import MagicMock
+from iconrpcserver.dispatcher.v3.icx import IcxDispatcher
+from iconrpcserver.dispatcher.validator import validate_jsonschema
+from iconrpcserver.utils import json_rpc
+
+
+@pytest.fixture
+def mock_server(monkeypatch):
+    async def mock_request(self_, method_name, **message):
+        expected_method_name = IcxDispatcher.icx_sendTransaction.__name__
+        if method_name != expected_method_name:
+            raise RuntimeError(f"Relay Tx with wrong name! "
+                               f"(expected: {expected_method_name}, actual: {method_name})")
+
+        validate_jsonschema(message)
+
+        response = MagicMock(Response)
+        response.data = SuccessResponse(result="^^!", jsonrpc="2.0", id=1)
+
+        return response
+
+    monkeypatch.setattr(json_rpc.AiohttpClient, "request", mock_request)
+
+
+@pytest.mark.asyncio
+async def test_relay_tx_request(mock_server):
+    relay_target = ""
+    path = ""
+    # https://github.com/icon-project/icon-rpc-server/blob/master/docs/icon-json-rpc-v3.md#icx_sendtransaction
+    message = {
+        "jsonrpc": "2.0",
+        "method": "icx_sendTransaction",
+        "id": 1234,
+        "params": {
+            "version": "0x3",
+            "from": "hxbe258ceb872e08851f1f59694dac2558708ece11",
+            "to": "hx5bfdb090f43a808005ffc27c25b213145e80b7cd",
+            "value": "0xde0b6b3a7640000",
+            "stepLimit": "0x12345",
+            "timestamp": "0x563a6cf330136",
+            "nid": "0x3",
+            "nonce": "0x1",
+            "signature": "VAia7YZ2Ji6igKWzjR2YsGa2m53nKPrfK7uXYW78QLE+ATehAVZPC40szvAiA6NEU5gCYB4c4qaQzqDh2ugcHgA="
+        }
+    }
+
+    await json_rpc.relay_tx_request(relay_target=relay_target, message=message, path=path)


### PR DESCRIPTION
# Goal
- Remove unused Option `REDIRECT_PROTOCOL`
> Now relay target is supplied from loopchain engine. So remove it to avoid possible confusions.