### PR TITLE
[LC-676] Refactoring WSDispatcher

### DIFF
--- a/iconrpcserver/dispatcher/default/websocket.py
+++ b/iconrpcserver/dispatcher/default/websocket.py
@@ -117,7 +117,6 @@ class WSDispatcher:
                 heartbeat_time = StubCollection().conf[ConfigKey.WS_HEARTBEAT_TIME]
                 await asyncio.sleep(heartbeat_time)
         except exceptions.ConnectionClosed:
-            traceback.print_exc()  # TODO: Keep this tb?
             Logger.debug("Connection Closed by child.")  # TODO: Useful message needed.
         except Exception as e:
             traceback.print_exc()  # TODO: Keep this tb?
@@ -144,7 +143,6 @@ class WSDispatcher:
                 await ws.send(json.dumps(request))
                 height += 1
         except exceptions.ConnectionClosed:
-            traceback.print_exc()  # TODO: Keep this tb?
             Logger.debug("Connection Closed by child.")  # TODO: Useful message needed.
         except Exception as e:
             traceback.print_exc()  # TODO: Keep this tb?

--- a/iconrpcserver/dispatcher/default/websocket.py
+++ b/iconrpcserver/dispatcher/default/websocket.py
@@ -15,17 +15,17 @@
 import asyncio
 import json
 import traceback
-from websockets import exceptions
 
 from iconcommons.logger import Logger
 from jsonrpcclient.request import Request
 from jsonrpcserver.aio import AsyncMethods
+from websockets import exceptions
 
 from iconrpcserver.default_conf.icon_rpcserver_constant import ConfigKey
 from iconrpcserver.protos import message_code
+from iconrpcserver.utils import get_now_timestamp
 from iconrpcserver.utils.json_rpc import get_channel_stub_by_channel_name
 from iconrpcserver.utils.message_queue.stub_collection import StubCollection
-from iconrpcserver.utils import get_now_timestamp
 
 ws_methods = AsyncMethods()
 
@@ -89,11 +89,12 @@ class WSDispatcher:
 
         async with Reception(channel_name, peer_id, remote_target) as registered:
             if not registered:
-                await WSDispatcher.send_and_raise_exception(
+                await WSDispatcher.send_exception(
                     ws=ws,
                     method="node_ws_PublishHeartbeat",
                     exception=RuntimeError("Unregistered"),
                     error_code=message_code.Response.fail_subscribe_limit)
+                return  # TODO: need to raise exception?
 
             futures = [
                 WSDispatcher.publish_heartbeat(ws),
@@ -104,56 +105,50 @@ class WSDispatcher:
 
     @staticmethod
     async def publish_heartbeat(ws):
-        exception = None
-        while ws.open:
+        call_method = "node_ws_PublishHeartbeat"
+        while True:
             try:
-                request = Request("node_ws_PublishHeartbeat")
-                Logger.debug(f"node_ws_PublishHeartbeat: {request}")
+                request = Request(call_method)
+                Logger.debug(f"{call_method}: {request}")
                 await ws.send(json.dumps(request))
                 heartbeat_time = StubCollection().conf[ConfigKey.WS_HEARTBEAT_TIME]
                 await asyncio.sleep(heartbeat_time)
+            except exceptions.ConnectionClosed:
+                Logger.debug("Connection Closed by child.")  # TODO: Useful message needed.
             except Exception as e:
-                exception = e
-                traceback.print_exc()
-                break
-
-        if not exception:
-            exception = ConnectionError("Connection closed.")
-
-        error_code = message_code.Response.fail_connection_closed
-        await WSDispatcher.send_and_raise_exception(ws, "node_ws_PublishHeartbeat", exception, error_code)
+                traceback.print_exc()  # TODO: Keep this tb?
+                await WSDispatcher.send_exception(
+                    ws, call_method,
+                    exception=e,
+                    error_code=message_code.Response.fail_connection_closed
+                )
 
     @staticmethod
     async def publish_new_block(ws, channel_name, height, peer_id):
-        exception = None
-        error_code = None
+        call_method = "node_ws_PublishNewBlock"
         channel_stub = get_channel_stub_by_channel_name(channel_name)
         try:
-            while ws.open:
+            while True:
                 new_block_dumped, confirm_info_bytes = await \
                     channel_stub.async_task().announce_new_block(subscriber_block_height=height, subscriber_id=peer_id)
                 new_block: dict = json.loads(new_block_dumped)
                 confirm_info = confirm_info_bytes.decode('utf-8')
-                request = Request("node_ws_PublishNewBlock", block=new_block, confirm_info=confirm_info)
-                Logger.debug(f"node_ws_PublishNewBlock: {request}")
+                request = Request(call_method, block=new_block, confirm_info=confirm_info)
+                Logger.debug(f"{call_method}: {request}")
 
                 await ws.send(json.dumps(request))
                 height += 1
-        except exceptions.ConnectionClosed as e:
-            exception = e
-            error_code = message_code.Response.fail_connection_closed
+        except exceptions.ConnectionClosed:
+            Logger.debug("Connection Closed by child.")  # TODO: Useful message needed.
         except Exception as e:
-            exception = e
-            error_code = message_code.Response.fail_announce_block
-            traceback.print_exc()
-
-        if not exception:
-            exception = ConnectionError("Connection closed.")
-
-        await WSDispatcher.send_and_raise_exception(ws, "node_ws_PublishNewBlock", exception, error_code)
+            traceback.print_exc()  # TODO: Keep this tb?
+            await WSDispatcher.send_exception(
+                ws, call_method,
+                exception=e,
+                error_code=message_code.Response.fail_announce_block
+            )
 
     @staticmethod
-    async def send_and_raise_exception(ws, method, exception, error_code):
+    async def send_exception(ws, method, exception, error_code):
         request = Request(method, error=str(exception), code=error_code)
         await ws.send(json.dumps(request))
-        raise exception

--- a/tests/dispatcher/conftest.py
+++ b/tests/dispatcher/conftest.py
@@ -1,0 +1,38 @@
+import functools
+
+import pytest
+
+
+class MockChannelInnerStub:
+    def __init__(self, mock_register_citizen, mock_unregister_citizen):
+        self.mock_register_citizen = mock_register_citizen
+        self.mock_unregister_citizen = mock_unregister_citizen
+
+    def async_task(self):
+        return self
+
+    async def register_citizen(self, peer_id, target, connected_time):
+        return self.mock_register_citizen()
+
+    async def unregister_citizen(self, peer_id):
+        return self.mock_unregister_citizen()
+
+
+@pytest.fixture
+def mock_channel_stub_factory(mocker):
+    def _mock_channel_stub(mocker_fixture, **kwargs_register_citizen_mock):
+        channel_register_citizen = mocker_fixture.MagicMock(**kwargs_register_citizen_mock)
+        channel_unregister_citizen = mocker_fixture.MagicMock()
+        mock_channel_stub = MockChannelInnerStub(mock_register_citizen=channel_register_citizen,
+                                                 mock_unregister_citizen=channel_unregister_citizen)
+
+        def mock_get_channel_stub_by_channel_name(channel_name):
+            return mock_channel_stub
+
+        mocker.patch("iconrpcserver.dispatcher.default.websocket.get_channel_stub_by_channel_name", mock_get_channel_stub_by_channel_name)
+
+        return mock_channel_stub
+
+    return functools.partial(_mock_channel_stub, mocker_fixture=mocker)
+
+

--- a/tests/dispatcher/test_reception.py
+++ b/tests/dispatcher/test_reception.py
@@ -1,0 +1,36 @@
+import pytest
+
+from iconrpcserver.dispatcher.default.websocket import Reception
+
+
+@pytest.mark.asyncio
+class TestReception:
+    async def test_register_citizen_and_channel_returns_true(self, mock_channel_stub_factory):
+        params_for_register_citizen_mock = {"return_value": True}
+        mock_channel_stub = mock_channel_stub_factory(**params_for_register_citizen_mock)
+
+        async with Reception(channel_name="", peer_id="", remote_target="") as registered:
+            assert mock_channel_stub.mock_register_citizen.called
+            assert registered
+
+        assert mock_channel_stub.mock_unregister_citizen.called
+
+    async def test_register_citizen_and_channel_returns_false(self, mock_channel_stub_factory):
+        params_for_register_citizen_mock = {"return_value": False}
+        mock_channel_stub = mock_channel_stub_factory(**params_for_register_citizen_mock)
+
+        async with Reception(channel_name="", peer_id="", remote_target="") as registered:
+            assert mock_channel_stub.mock_register_citizen.called
+            assert not registered
+
+        assert mock_channel_stub.mock_unregister_citizen.called
+
+    async def test_register_citizen_and_raised_exc_during_communicate(self, mock_channel_stub_factory):
+        params_for_register_citizen_mock = {"side_effect": RuntimeError("SUBSCRIBE_LIMIT or Already registered!!")}
+        mock_channel_stub = mock_channel_stub_factory(**params_for_register_citizen_mock)
+
+        async with Reception(channel_name="", peer_id="", remote_target="") as registered:
+            assert mock_channel_stub.mock_register_citizen.called
+            assert not registered
+
+        assert mock_channel_stub.mock_unregister_citizen.called

--- a/tests/dispatcher/test_ws_dispatcher.py
+++ b/tests/dispatcher/test_ws_dispatcher.py
@@ -1,0 +1,113 @@
+import json
+
+import pytest
+from jsonrpcclient.request import Request
+
+from iconrpcserver.dispatcher.default.websocket import WSDispatcher
+from iconrpcserver.protos import message_code
+
+
+@pytest.fixture
+def request_dict():
+    peer_id = "0xaaaaaa"
+    context = {
+        "channel": "icon_dex",
+        "peer_id": peer_id,
+        "ws": "mock_ws",
+        "remote_target": f"iii.pp.ii.ppp:pppp"
+    }
+
+    return {
+        "context": context,
+        "height": 1,
+        "peer_id": peer_id
+    }
+
+
+@pytest.mark.asyncio
+class TestWSDispatcher:
+    @pytest.fixture
+    def mock_publish_method_factory(self, mocker, mock_channel_stub_factory):
+        def _mock_publish_method(**kwargs_for_mock):
+            check_by_this_method = mocker.MagicMock(**kwargs_for_mock)
+
+            async def _this_async_mock_will_substitute_origin_func(*args, **kwargs):
+                return check_by_this_method(*args, **kwargs)
+
+            return check_by_this_method, _this_async_mock_will_substitute_origin_func
+
+        return _mock_publish_method
+
+    async def test_do_publish_if_register_succeed(self, mocker, request_dict, mock_channel_stub_factory, mock_publish_method_factory):
+        mock_value = {"return_value": True}
+        mock_channel_stub_factory(**mock_value)
+        publish_heartbeat, mock_publish_heartbeat = mock_publish_method_factory(**mock_value)
+        publish_new_block, mock_publish_new_block = mock_publish_method_factory(**mock_value)
+
+        mocker.patch.object(WSDispatcher, "publish_heartbeat", new=mock_publish_heartbeat)
+        mocker.patch.object(WSDispatcher, "publish_new_block", new=mock_publish_new_block)
+        await WSDispatcher.node_ws_Subscribe(**request_dict)
+
+        assert publish_heartbeat.called
+        assert publish_new_block.called
+
+    async def test_no_publish_if_register_fail(self, mocker, request_dict, mock_channel_stub_factory, mock_publish_method_factory):
+        mock_value = {"return_value": False}
+        mock_channel_stub_factory(**mock_value)
+        publish_heartbeat, mock_publish_heartbeat = mock_publish_method_factory(**mock_value)
+        publish_new_block, mock_publish_new_block = mock_publish_method_factory(**mock_value)
+        send_exception, mock_send_exception = mock_publish_method_factory(**mock_value)
+
+        mocker.patch.object(WSDispatcher, "publish_heartbeat", new=mock_publish_heartbeat)
+        mocker.patch.object(WSDispatcher, "publish_new_block", new=mock_publish_new_block)
+        mocker.patch.object(WSDispatcher, "send_exception", new=mock_send_exception)
+        await WSDispatcher.node_ws_Subscribe(**request_dict)
+
+        assert not publish_heartbeat.called
+        assert not publish_new_block.called
+        assert send_exception.called
+
+    async def test_no_publish_if_exc_during_register(self, mocker, request_dict, mock_channel_stub_factory, mock_publish_method_factory):
+        reception_mock_value = {"side_effect": RuntimeError("REGISTER FAILED DURING CHANNEL STUB")}
+        mock_channel_stub_factory(**reception_mock_value)
+
+        mock_publish_value = {"return_value": True}
+        publish_heartbeat, mock_publish_heartbeat = mock_publish_method_factory(**mock_publish_value)
+        publish_new_block, mock_publish_new_block = mock_publish_method_factory(**mock_publish_value)
+        send_exception, mock_send_exception = mock_publish_method_factory(**mock_publish_value)
+
+        mocker.patch.object(WSDispatcher, "publish_heartbeat", new=mock_publish_heartbeat)
+        mocker.patch.object(WSDispatcher, "publish_new_block", new=mock_publish_new_block)
+        mocker.patch.object(WSDispatcher, "send_exception", new=mock_send_exception)
+        await WSDispatcher.node_ws_Subscribe(**request_dict)
+
+        assert not publish_heartbeat.called
+        assert not publish_new_block.called
+        assert send_exception.called
+
+    async def test_send_exception(self, mocker, mock_channel_stub_factory):
+        class MockWebSocket:
+            def __init__(self, mocker_fixture):
+                self.mock_send = mocker_fixture.MagicMock()
+
+            async def send(self, *args, **kwargs):
+                self.mock_send(*args, **kwargs)
+
+        ws = MockWebSocket(mocker)
+        expected_method = "fake_method"
+        expected_exc = RuntimeError("test")
+        expected_error_code = message_code.Response.fail_subscribe_limit
+
+        await WSDispatcher.send_exception(ws, method=expected_method, exception=expected_exc, error_code=expected_error_code)
+
+        expected_request = Request(method=expected_method, error=str(expected_exc), code=expected_error_code)
+        expected_called_params = dict(expected_request)
+
+        actual_called_params, _ = ws.mock_send.call_args
+        actual_called_params: dict = json.loads(actual_called_params[0])
+
+        # Remove id because jsonrpc call auto-increments request id.
+        expected_called_params.pop("id")
+        actual_called_params.pop("id")
+
+        assert actual_called_params == expected_called_params


### PR DESCRIPTION
**This is a parent side (those who is requested) between connection. (CHILD CODE: https://github.com/icon-project/loopchain/pull/370)**

# Changes
> (Terms - NOT OFFITIAL!)
> - CHILD: Requesting side between connnection and connection close is made by this side.
> - PARENT: Being requested side and publish blocks and heartbeat to CHILD, including exception.

- Connection close must be made by the child side.
- Send exception to child side if unacceptable situation happend in parent side. This makes child side to close connection.
