### PR TITLE
[LC-711] add first heartbeat sending when registered

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,7 @@ secp256k1==0.13.2
 sanic-cors==0.9.6
 earlgrey>=0.0.4
 iconcommons>=1.0.5
+pytest
+pytest-asyncio
+asyncmock
+pytest-mock

--- a/tests/dispatcher/conftest.py
+++ b/tests/dispatcher/conftest.py
@@ -1,38 +1,26 @@
-import functools
-
 import pytest
+
+from iconrpcserver.utils.message_queue.channel_inner_stub import ChannelInnerStub
+from iconrpcserver.utils.message_queue.stub_collection import StubCollection
+
+CHANNEL_STUB_NAME = "icon_dex"
 
 
 class MockChannelInnerStub:
-    def __init__(self, mock_register_citizen, mock_unregister_citizen):
-        self.mock_register_citizen = mock_register_citizen
-        self.mock_unregister_citizen = mock_unregister_citizen
-
     def async_task(self):
         return self
 
     async def register_citizen(self, peer_id, target, connected_time):
-        return self.mock_register_citizen()
+        pass
 
     async def unregister_citizen(self, peer_id):
-        return self.mock_unregister_citizen()
+        pass
+
+    async def wait_for_unregister_signal(self, peer_id):
+        pass
 
 
-@pytest.fixture
-def mock_channel_stub_factory(mocker):
-    def _mock_channel_stub(mocker_fixture, **kwargs_register_citizen_mock):
-        channel_register_citizen = mocker_fixture.MagicMock(**kwargs_register_citizen_mock)
-        channel_unregister_citizen = mocker_fixture.MagicMock()
-        mock_channel_stub = MockChannelInnerStub(mock_register_citizen=channel_register_citizen,
-                                                 mock_unregister_citizen=channel_unregister_citizen)
-
-        def mock_get_channel_stub_by_channel_name(channel_name):
-            return mock_channel_stub
-
-        mocker.patch("iconrpcserver.dispatcher.default.websocket.get_channel_stub_by_channel_name", mock_get_channel_stub_by_channel_name)
-
-        return mock_channel_stub
-
-    return functools.partial(_mock_channel_stub, mocker_fixture=mocker)
-
-
+@pytest.fixture(autouse=True)
+def patch_stubcollection():
+    mock_channel_stub: ChannelInnerStub = MockChannelInnerStub()
+    StubCollection().channel_stubs[CHANNEL_STUB_NAME] = mock_channel_stub

--- a/tests/dispatcher/test_reception.py
+++ b/tests/dispatcher/test_reception.py
@@ -1,36 +1,42 @@
 import pytest
+from asyncmock import AsyncMock
 
 from iconrpcserver.dispatcher.default.websocket import Reception
+from iconrpcserver.utils.message_queue.stub_collection import StubCollection
+from .conftest import CHANNEL_STUB_NAME, MockChannelInnerStub
 
 
 @pytest.mark.asyncio
 class TestReception:
-    async def test_register_citizen_and_channel_returns_true(self, mock_channel_stub_factory):
-        params_for_register_citizen_mock = {"return_value": True}
-        mock_channel_stub = mock_channel_stub_factory(**params_for_register_citizen_mock)
+    async def test_register_citizen_and_channel_returns_true(self):
+        channel_stub: MockChannelInnerStub = StubCollection().channel_stubs[CHANNEL_STUB_NAME]
+        channel_stub.register_citizen = AsyncMock(return_value=True)
+        channel_stub.unregister_citizen = AsyncMock()
 
-        async with Reception(channel_name="", peer_id="", remote_target="") as registered:
-            assert mock_channel_stub.mock_register_citizen.called
+        async with Reception(channel_name=CHANNEL_STUB_NAME, peer_id="", remote_target="") as registered:
+            assert channel_stub.register_citizen.called
             assert registered
 
-        assert mock_channel_stub.mock_unregister_citizen.called
+        assert channel_stub.unregister_citizen.called
 
-    async def test_register_citizen_and_channel_returns_false(self, mock_channel_stub_factory):
-        params_for_register_citizen_mock = {"return_value": False}
-        mock_channel_stub = mock_channel_stub_factory(**params_for_register_citizen_mock)
+    async def test_register_citizen_and_channel_returns_false(self):
+        channel_stub: MockChannelInnerStub = StubCollection().channel_stubs[CHANNEL_STUB_NAME]
+        channel_stub.register_citizen = AsyncMock(return_value=False)
+        channel_stub.unregister_citizen = AsyncMock()
 
-        async with Reception(channel_name="", peer_id="", remote_target="") as registered:
-            assert mock_channel_stub.mock_register_citizen.called
+        async with Reception(channel_name=CHANNEL_STUB_NAME, peer_id="", remote_target="") as registered:
+            assert channel_stub.register_citizen.called
             assert not registered
 
-        assert mock_channel_stub.mock_unregister_citizen.called
+        assert channel_stub.unregister_citizen.called
 
-    async def test_register_citizen_and_raised_exc_during_communicate(self, mock_channel_stub_factory):
-        params_for_register_citizen_mock = {"side_effect": RuntimeError("SUBSCRIBE_LIMIT or Already registered!!")}
-        mock_channel_stub = mock_channel_stub_factory(**params_for_register_citizen_mock)
+    async def test_register_citizen_and_raised_exc_during_communicate(self):
+        channel_stub: MockChannelInnerStub = StubCollection().channel_stubs[CHANNEL_STUB_NAME]
+        channel_stub.register_citizen = AsyncMock(side_effect=RuntimeError("SUBSCRIBE_LIMIT or Already registered!!"))
+        channel_stub.unregister_citizen = AsyncMock()
 
-        async with Reception(channel_name="", peer_id="", remote_target="") as registered:
-            assert mock_channel_stub.mock_register_citizen.called
+        async with Reception(channel_name=CHANNEL_STUB_NAME, peer_id="", remote_target="") as registered:
+            assert channel_stub.register_citizen.called
             assert not registered
 
-        assert mock_channel_stub.mock_unregister_citizen.called
+        assert channel_stub.unregister_citizen.called


### PR DESCRIPTION
When a citizen is properly registered, sending first heartbeat was added to notice the citizen that it's registered.