### PR TITLE
[LC-715] Add check_response_code in `icx_getBlock`

### DIFF
--- a/iconrpcserver/dispatcher/v3/icx.py
+++ b/iconrpcserver/dispatcher/v3/icx.py
@@ -36,6 +36,15 @@ BLOCK_v0_1a = '0.1a'
 BLOCK_v0_3 = '0.3'
 
 
+def check_response_code(response_code: message_code.Response):
+    if response_code != message_code.Response.success:
+        raise GenericJsonRpcServerError(
+            code=JsonError.INVALID_PARAMS,
+            message=message_code.responseCodeMap[response_code][1],
+            http_status=status.HTTP_BAD_REQUEST
+        )
+
+
 class IcxDispatcher:
     @staticmethod
     @methods.add
@@ -219,6 +228,10 @@ class IcxDispatcher:
         else:
             block_hash, result = await get_block_by_params(block_height=-1,
                                                            channel_name=channel)
+
+        response_code = result['response_code']
+        check_response_code(response_code)
+
         block = result['block']
         if block['version'] == BLOCK_v0_1a:
             response = convert_params(result['block'], ResponseParamType.get_block_v0_1a_tx_v3)
@@ -248,12 +261,7 @@ class IcxDispatcher:
                                                        channel_name=channel)
 
         response_code = result['response_code']
-        if response_code != message_code.Response.success:
-            raise GenericJsonRpcServerError(
-                code=JsonError.INVALID_PARAMS,
-                message=message_code.responseCodeMap[response_code][1],
-                http_status=status.HTTP_BAD_REQUEST
-            )
+        check_response_code(response_code)
 
         response = convert_params(result['block'], ResponseParamType.get_block_v0_1a_tx_v3)
         return response
@@ -266,12 +274,7 @@ class IcxDispatcher:
         block_hash, result = await get_block_by_params(block_height=request['height'],
                                                        channel_name=channel)
         response_code = result['response_code']
-        if response_code != message_code.Response.success:
-            raise GenericJsonRpcServerError(
-                code=JsonError.INVALID_PARAMS,
-                message=message_code.responseCodeMap[response_code][1],
-                http_status=status.HTTP_BAD_REQUEST
-            )
+        check_response_code(response_code)
 
         response = convert_params(result['block'], ResponseParamType.get_block_v0_1a_tx_v3)
         return response


### PR DESCRIPTION
# Goal
- Fix return message when requested invalid height or hash: 
> before: `{"jsonrpc": "2.0", "error": {"code": -32000, "message": "Server error"}, "id": 1234}`
> after: 
> - invalid block height: `{"jsonrpc": "2.0", "error": {"code": -32602, "message": "fail wrong block height"}, "id": 1234}`
> - invalid hash: `{"jsonrpc": "2.0", "error": {"code": -32602, "message": "JSON schema validation error: 'hash' has an invalid value"}, "id": 1234}`


- Fix wrong traceback when faced the situation above.
