### PR TITLE
[LC-790] fix bug in checking error in new_block

### DIFF
--- a/iconrpcserver/dispatcher/default/websocket.py
+++ b/iconrpcserver/dispatcher/default/websocket.py
@@ -143,8 +143,8 @@ class WSDispatcher:
                 )
                 new_block: dict = json.loads(new_block_dumped)
 
-                if "error" in new_block_dumped:
-                    Logger.error(f"announce_new_block error: {new_block_dumped}, to citizen({peer_id})")
+                if "error" in new_block:
+                    Logger.error(f"announce_new_block error: {new_block}, to citizen({peer_id})")
                     break
 
                 confirm_info = confirm_info_bytes.decode('utf-8')


### PR DESCRIPTION
Fix bug when checking 'error' in new_block. (to restrict the data to new_block.keys()) 