### PR TITLE
[LC-806] Add logic to reset network.

### DIFF
--- a/iconrpcserver/dispatcher/default/websocket.py
+++ b/iconrpcserver/dispatcher/default/websocket.py
@@ -145,6 +145,7 @@ class WSDispatcher:
 
                 if "error" in new_block:
                     Logger.error(f"announce_new_block error: {new_block}, to citizen({peer_id})")
+                    channel_stub.sync_task().try_block_sync(height)
                     break
 
                 confirm_info = confirm_info_bytes.decode('utf-8')

--- a/iconrpcserver/utils/message_queue/channel_inner_stub.py
+++ b/iconrpcserver/utils/message_queue/channel_inner_stub.py
@@ -46,6 +46,10 @@ class ChannelInnerTask:
         pass
 
     @message_queue_task
+    def try_block_sync(self, subscriber_block_height: int):
+        pass
+
+    @message_queue_task
     async def get_tx_proof(self, tx_hash: str) -> list:
         pass
 


### PR DESCRIPTION
(coupled: https://github.com/icon-project/loopchain/pull/454)

- Add logic to reset network when a node gets a request that wants to send a block from a subscriber that has a higher height than it.