### PR TITLE
[LC-891] Fix mismatch in AioHttpClient Protocol

### DIFF
--- a/iconrpcserver/utils/json_rpc.py
+++ b/iconrpcserver/utils/json_rpc.py
@@ -20,6 +20,7 @@ import async_timeout
 from iconcommons.logger import Logger
 from jsonrpcclient import exceptions
 from jsonrpcclient.async_client import AsyncClient
+from jsonrpcclient.response import Response
 from jsonrpcserver import status
 
 from ..dispatcher import GenericJsonRpcServerError, JsonError
@@ -94,7 +95,8 @@ async def relay_tx_request(protocol, message, relay_target, path, version=ApiVer
                     f"relay_target[{relay_target}], "
                     f"version[{version}], "
                     f"method[{method_name}]")
-        result = await CustomAiohttpClient(session, relay_uri).request(method_name, message)
+        result: Response = await CustomAiohttpClient(session, relay_uri).request(method_name, message)
+        result = result.data.result
         Logger.debug(f"relay_tx_request result[{result}]")
 
     return result


### PR DESCRIPTION
(coupled: https://github.com/icon-project/loopchain/pull/480)

# Please read
- `jsonrpcclient.client.Client.send` ensures `jsonrpcclient.response.Response`.
- `jsonrpcclient.response.Response` has its response result in `.data.result`  
> See: https://jsonrpcclient.readthedocs.io/en/latest/api.html#response

# Goal
- Fix violation of API above. (Caused by: https://github.com/icon-project/icon-rpc-server/pull/128)