### PR TITLE
support get_blockReceipts API

### DIFF
--- a/docs/icon-json-rpc-v3.md
+++ b/docs/icon-json-rpc-v3.md
@@ -118,6 +118,7 @@ Below table shows the default error messages for the error code. Actual message 
     * v2: "data_type"
     * v3: "dataType"
 * Removed tx_hash from the icx_sendTransaction message.
+* Append icx_getBlockReceipts API
 
 # JSON-RPC APIs
 
@@ -142,6 +143,7 @@ API path : `<scheme>://<host>/api/v3`
 * [icx_proveTransaction](#icx_provetransaction)
 * [icx_proveReceipt](#icx_provereceipt)
 * [icx_sendTransaction](#icx_sendtransaction)
+* [icx_getBlockReceipts](#icx_getblockreceipts)
 
 ## Debug API
 
@@ -1757,6 +1759,124 @@ Information of Account
     "id": 1234
 }
 ```
+
+
+
+## icx_getBlockReceipts
+
+* Returns the block receipts by given parameter.
+
+### Parameters
+
+| KEY    | VALUE type        | Description               |
+| :----- | :---------------- | :------------------------ |
+| hash   | [T_HASH](#T_HASH) | Hash of a block           |
+| height | [T_INT](#T_INT)   | Integer of a block height |
+| None   | -                 | Last block                |
+
+### Returns
+
+Block Receipts data (including v0.3)
+
+### Example
+
+```javascript
+// Request 1 - get last block receipts
+{
+    "jsonrpc": "2.0",
+    "method": "icx_getBlockReceipts",
+    "id": 1234
+}
+
+// Request 2 - get block receipts by hash
+{
+    "jsonrpc": "2.0",
+    "method": "icx_getBlockReceipts",
+    "id": 1234,
+    "params": {
+        "hash": "0x6d4a4dbb950152050684eef5d0e228b8a31cae7afd37d9760b79312305008977"
+    }
+}
+
+// Request 3 - get block receipts by height
+{
+    "jsonrpc": "2.0",
+    "method": "icx_getBlockReceipts",
+    "id": 1234,
+    "params": {
+        "height": "0x4"
+    }
+}
+
+// Response - success
+{
+    "jsonrpc": "2.0",
+    "result": [
+		{
+			"txHash": "4b9afccf0ce595fc67fd84959d8ff3107aad2e78ea418d8e115d39dbb5ddf683",
+			"blockHeight": "0x696",
+			"blockHash": "59415879e59977ac29bfa5dcfff3dfff2604beb0f1ba97d1944caf90b39d4c49",
+			"txIndex": "0x0",
+			"to": "hxe3d6d5d8e433fbd13b9c481d11cf46cebd84b23c",
+			"stepUsed": "0x0",
+			"stepPrice": "0x0",
+			"cumulativeStepUsed": "0x0",
+			"eventLogs": [
+				{
+					"scoreAddress": "cx0000000000000000000000000000000000000000",
+					"indexed": [
+						"PRepIssued(int,int,int,int)"
+					],
+					"data": [
+						"0xa968163f0a57b400000",
+						"0x477",
+						"0xd3e02419de2130fd07fe4",
+						"0x20bd5ed6b99b1fcb"
+					]
+				},
+				{
+					"scoreAddress": "cx0000000000000000000000000000000000000000",
+					"indexed": [
+						"ICXIssued(int,int,int,int)"
+					],
+					"data": [
+						"0x0",
+						"0x20bd5ed6b99b1fcb",
+						"0x0",
+						"0x53a06a5e791a89dbe"
+					]
+				}
+			],
+			"status": "0x1"
+		}
+	],
+  "id": 1234
+}
+
+// Request (fail if both parameters are in request message.)
+{
+    "jsonrpc": "2.0",
+    "method": "icx_getBlockReceipts",
+    "id": 1234,
+    "params": {
+        "hash": "0x6d4a4dbb950152050684eef5d0e228b8a31cae7afd37d9760b79312305008977",
+        "height": "0x4"
+    }
+}
+ 
+ 
+// Response - fail
+{
+    "jsonrpc": "2.0",
+    "id": 1234,
+    "error": {
+        "code": -32602,
+        "message": "Invalid params (only one parameter is allowed)"
+    }
+}
+```
+
+## 
 
 ## References
 

--- a/iconrpcserver/dispatcher/validator.py
+++ b/iconrpcserver/dispatcher/validator.py
@@ -758,6 +758,27 @@ debug_getAccount_v3: dict = {
     "required": ["jsonrpc", "method", "id", "params"]
 }
 
+icx_getBlockReceipts: dict = {
+    "title": "icx_getBlockReceipts",
+    "id": "https://github.com/icon-project/icon-rpc-server/blob/master/docs/icon-json-rpc-v3.md",
+    "type": "object",
+    "properties": {
+        "jsonrpc": {"type": "string", "enum": ["2.0"]},
+        "method": {"type": "string"},
+        "id": {"type": ["number", "string"]},
+        "params": {
+            "type": "object",
+            "properties": {
+                "hash": {"type": "string", "format": "hash"},
+                "height": {"type": "string", "format": "int_16"},
+            },
+            "additionalProperties": False
+        }
+    },
+    "additionalProperties": False,
+    "required": ["jsonrpc", "method", "id"]
+}
+
 SCHEMA_V3: dict = {
     "icx_getBlock": icx_getBlock,
     "icx_getLastBlock": icx_getLastBlock,
@@ -778,6 +799,7 @@ SCHEMA_V3: dict = {
     "ise_getStatus": ise_getStatus_v3,
     "rep_getListByHash": rep_getListByHash_v3,
     "debug_getAccount": debug_getAccount_v3,
+    "icx_getBlockReceipts": icx_getBlockReceipts
 }
 
 

--- a/iconrpcserver/utils/icon_service/__init__.py
+++ b/iconrpcserver/utils/icon_service/__init__.py
@@ -43,6 +43,7 @@ class RequestParamType(Enum):
     get_block_by_height = 10
     get_tx_result = 11
     get_reps_by_hash = 12
+    get_block_receipts = 13
 
 
 class ResponseParamType(Enum):
@@ -52,6 +53,7 @@ class ResponseParamType(Enum):
     get_block_v0_1a_tx_v2 = 3
     get_block_v0_1a_tx_v3 = 4
     get_block_v0_3_tx_v3 = 5
+    get_block_receipts = 6
 
 
 def check_error_response(result: Any):

--- a/iconrpcserver/utils/icon_service/templates.py
+++ b/iconrpcserver/utils/icon_service/templates.py
@@ -117,6 +117,8 @@ templates[RequestParamType.get_reps_by_hash] = {
     "repsHash": ValueType.hex_0x_hash_number
 }
 
+templates[RequestParamType.get_block_receipts] = templates[RequestParamType.get_block]
+
 # ======== templates for Response =========
 
 BLOCK_0_1a = {
@@ -201,3 +203,11 @@ templates[ResponseParamType.get_tx_by_hash] = {
 
 templates[ResponseParamType.send_tx] = ValueType.hex_0x_hash_number
 
+templates[ResponseParamType.get_block_receipts] = {
+    "tx_results": [
+        {
+            "txHash": ValueType.hex_0x_hash_number,
+            "blockHash": ValueType.hex_0x_hash_number,
+        }
+    ]
+}

--- a/iconrpcserver/utils/message_queue/channel_inner_stub.py
+++ b/iconrpcserver/utils/message_queue/channel_inner_stub.py
@@ -171,6 +171,16 @@ class ChannelInnerTask:
         """
         pass
 
+    @message_queue_task
+    async def get_block_receipts(self, block_height, block_hash) -> Tuple[int, str]:
+        """Get block receipts via v3
+
+        :param block_height:
+        :param block_hash:
+        :return: (response_code, block_receipts_json)
+        """
+        pass
+
 
 class ChannelInnerStub(MessageQueueStub[ChannelInnerTask]):
     TaskType = ChannelInnerTask

--- a/tests/dispatcher/conftest.py
+++ b/tests/dispatcher/conftest.py
@@ -858,6 +858,52 @@ def create_channel_stub(**kwargs) -> ChannelInnerStub:
         }
     ]
 
+    # Block Receipts
+    block_receipts_sample_response = [
+        {
+            "txHash": "4b9afccf0ce595fc67fd84959d8ff3107aad2e78ea418d8e115d39dbb5ddf683",
+            "blockHeight": "0x696",
+            "blockHash": "59415879e59977ac29bfa5dcfff3dfff2604beb0f1ba97d1944caf90b39d4c49",
+            "txIndex": "0x0",
+            "to": "hxe3d6d5d8e433fbd13b9c481d11cf46cebd84b23c",
+            "stepUsed": "0x0",
+            "stepPrice": "0x0",
+            "cumulativeStepUsed": "0x0",
+            "eventLogs": [
+                {
+                    "scoreAddress": "cx0000000000000000000000000000000000000000",
+                    "indexed": [
+                        "PRepIssued(int,int,int,int)"
+                    ],
+                    "data": [
+                        "0xa968163f0a57b400000",
+                        "0x477",
+                        "0xd3e02419de2130fd07fe4",
+                        "0x20bd5ed6b99b1fcb"
+                    ]
+                },
+                {
+                    "scoreAddress": "cx0000000000000000000000000000000000000000",
+                    "indexed": [
+                        "ICXIssued(int,int,int,int)"
+                    ],
+                    "data": [
+                        "0x0",
+                        "0x20bd5ed6b99b1fcb",
+                        "0x0",
+                        "0x53a06a5e791a89dbe"
+                    ]
+                }
+            ],
+            "status": "0x1"
+        }]
+
+    # response_code, block_hash, confirm_info, block_data_json
+    task.get_block_receipts.return_value = (
+        kwargs.get("response_code"),
+        json.dumps(block_receipts_sample_response)
+    )
+
     stub: ChannelInnerStub = MagicMock(ChannelInnerStub)
     stub.async_task.return_value = task
 

--- a/tests/dispatcher/conftest.py
+++ b/tests/dispatcher/conftest.py
@@ -598,7 +598,35 @@ REQUESTS_V3 = {
                 "repsHash": "0xe08f93fac84433f8220c18e415e15c6e837539de2aa7d9d6cb953acd8cdd609e"
             }
         }
-    ]
+    ],
+    "icx_getBlockReceipts": {
+        "jsonrpc": "2.0",
+        "method": "icx_getBlockReceipts",
+        "id": 1234
+    },
+    "icx_getBlockReceipts_batch": [
+        {
+            "jsonrpc": "2.0",
+            "method": "icx_getBlockReceipts",
+            "id": 1234
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "icx_getBlockReceipts",
+            "id": 1234,
+            "params": {
+                "height": "0x1"
+            }
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "icx_getBlockReceipts",
+            "id": 1234,
+            "params": {
+                "hash": "0xcf43b3fd45981431a0e64f79d07bfcf703e064b73b802c5f32834eec72142190",
+            }
+        },
+    ],
 }
 
 

--- a/tests/dispatcher/test_dispatcher_v3.py
+++ b/tests/dispatcher/test_dispatcher_v3.py
@@ -386,6 +386,7 @@ class TestVersion3Dispatcher(TestDispatcher):
         # Then response is not error
         for json_data in result_json:
             assert 'error' not in json_data, f"request = {json_request_batch}"
+
     async def test_icx_proveReceipt(self, mock_channel, test_cli):
         # Given I receives icx_proveReceipt request
         json_request = copy.deepcopy(self.REQUESTS["icx_proveReceipt"])
@@ -442,6 +443,33 @@ class TestVersion3Dispatcher(TestDispatcher):
     async def test_rep_getListByHash_batch(self, mock_channel, test_cli):
         # Given I receives rep_getListByHash batch request
         json_request_batch = copy.deepcopy(self.REQUESTS["rep_getListByHash"])
+        # And the node is a validator
+        mock_channel(response_code=message_code.Response.success)
+
+        # When I call dispatch method
+        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = await response.json()
+
+        # Then response is not error
+        for json_data in result_json:
+            assert 'error' not in json_data, f"request = {json_request_batch}"
+
+    async def test_icx_getBlockReceipts(self, mock_channel, test_cli):
+        # Given I receives icx_getBlock request
+        json_request = copy.deepcopy(self.REQUESTS["icx_getBlockReceipts"])
+        # And the node is a validator
+        mock_channel(response_code=message_code.Response.success)
+
+        # When I call dispatch method
+        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = await response.json()
+
+        # Then response is not error
+        assert 'error' not in result_json, f"request = {json_request}"
+
+    async def test_icx_getBlockReceipts_batch(self, mock_channel, test_cli):
+        # Given I receives icx_getBlock batch request
+        json_request_batch = copy.deepcopy(self.REQUESTS["icx_getBlockReceipts_batch"])
         # And the node is a validator
         mock_channel(response_code=message_code.Response.success)
 


### PR DESCRIPTION
We support API to get block receipts at once. (API V3)

reference API Klaytn getBlockReceipts

```javascript
Example
// Request 1 - get last block receipts
{
    "jsonrpc": "2.0",
    "method": "icx_getBlockReceipts",
    "id": 1234
}

// Request 2 - get block receipts by hash
{
    "jsonrpc": "2.0",
    "method": "icx_getBlockReceipts",
    "id": 1234,
    "params": {
        "hash": "0x6d4a4dbb950152050684eef5d0e228b8a31cae7afd37d9760b79312305008977"
    }
}

// Request 3 - get block receipts by height
{
    "jsonrpc": "2.0",
    "method": "icx_getBlockReceipts",
    "id": 1234,
    "params": {
        "height": "0x4"
    }
}

// Response - success
{
    "jsonrpc": "2.0",
    "result": [
		{
			"txHash": "4b9afccf0ce595fc67fd84959d8ff3107aad2e78ea418d8e115d39dbb5ddf683",
			"blockHeight": "0x696",
			"blockHash": "59415879e59977ac29bfa5dcfff3dfff2604beb0f1ba97d1944caf90b39d4c49",
			"txIndex": "0x0",
			"to": "hxe3d6d5d8e433fbd13b9c481d11cf46cebd84b23c",
			"stepUsed": "0x0",
			"stepPrice": "0x0",
			"cumulativeStepUsed": "0x0",
			"eventLogs": [
				{
					"scoreAddress": "cx0000000000000000000000000000000000000000",
					"indexed": [
						"PRepIssued(int,int,int,int)"
					],
					"data": [
						"0xa968163f0a57b400000",
						"0x477",
						"0xd3e02419de2130fd07fe4",
						"0x20bd5ed6b99b1fcb"
					]
				},
				{
					"scoreAddress": "cx0000000000000000000000000000000000000000",
					"indexed": [
						"ICXIssued(int,int,int,int)"
					],
					"data": [
						"0x0",
						"0x20bd5ed6b99b1fcb",
						"0x0",
						"0x53a06a5e791a89dbe"
					]
				}
			],
			"status": "0x1"
		}
	],
  "id": 1234
}
```