### PR TITLE
[IS-1375] update aiohttp, typing-extensions requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp<=3.7.3
 jsonschema~=3.2.0
 jsonrpcserver~=4.1.2
 jsonrpcclient[aiohttp]~=3.3.5
@@ -6,3 +7,4 @@ gunicorn~=20.0.0
 sanic-cors~=0.10.0
 earlgrey~=0.2.1
 iconcommons~=1.1.3
+typing-extensions~=3.7.4


### PR DESCRIPTION
 - fixed mismatch `chardet` version with loopchain requires
   `aiohttp` 3.7.4.post0 requires `chardet` 4.0.0
 - fixed mismatch `typing-extensions` version with iconservice requires