### PR TITLE
[IS-1378] fixed security alert

### DIFF
--- a/iconrpcserver/server/rest_server.py
+++ b/iconrpcserver/server/rest_server.py
@@ -138,18 +138,16 @@ async def get_channel_status(channel_name) -> dict:
 
 
 class Status(HTTPMethodView):
-    async def get(self, request):
-        args = request.raw_args
-        channel_name = args.get('channel') or ServerComponents.conf.get(ConfigKey.CHANNEL)
+    async def get(self, request, *args, **kwargs):
+        channel_name = request.args.get('channel') or ServerComponents.conf.get(ConfigKey.CHANNEL)
         status_data: dict = await get_channel_status(channel_name)
 
         return response.json(status_data)
 
 
 class Avail(HTTPMethodView):
-    async def get(self, request):
-        args = request.raw_args
-        channel_name = args.get('channel') or ServerComponents.conf.get(ConfigKey.CHANNEL)
+    async def get(self, request, *args, **kwargs):
+        channel_name = request.args.get('channel') or ServerComponents.conf.get(ConfigKey.CHANNEL)
         status = HTTPStatus.OK
         result: dict = await get_channel_status(channel_name)
 
@@ -160,8 +158,8 @@ class Avail(HTTPMethodView):
 
 
 class Disable(HTTPMethodView):
-    async def get(self, request):
+    async def get(self, request, *args, **kwargs):
         return response.text("This api version not support any more!")
 
-    async def post(self, request):
+    async def post(self, request, *args, **kwargs):
         return response.text("This api version not support any more!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-aiohttp<=3.7.3
+aiohttp<=3.7.4
 jsonschema~=3.2.0
 jsonrpcserver~=4.1.2
 jsonrpcclient[aiohttp]~=3.3.5
-sanic~=19.12.2
+sanic~=21.6.0
 gunicorn~=20.0.0
-sanic-cors~=0.10.0
+sanic-cors~=1.0.0
 earlgrey~=0.2.1
 iconcommons~=1.1.3
 typing-extensions~=3.7.4

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open('requirements.txt') as requirements:
         install_requires.append(req)
 
 extras_requires = {
-    'tests': ['pytest~=5.4.2', 'pytest-asyncio~=0.12.0', 'mock~=4.0.1', 'pytest-sanic~=1.6.1']
+    'tests': ['pytest~=5.4.2', 'pytest-asyncio~=0.12.0', 'mock~=4.0.1', 'pytest-sanic~=1.8.1']
 }
 
 setup_options = {

--- a/tests/dispatcher/conftest.py
+++ b/tests/dispatcher/conftest.py
@@ -658,7 +658,7 @@ def patch_stubcollection():
 
 @pytest.yield_fixture
 def app():
-    sanic_app = Sanic("test_sanic_app")
+    sanic_app = Sanic("test_sanic_app", register=False)
 
     sanic_app.add_route(NodeDispatcher.dispatch, '/api/node/', methods=['POST'])
     sanic_app.add_route(Version2Dispatcher.dispatch, '/api/v2/', methods=['POST'])

--- a/tests/dispatcher/test_dispatcher_v2.py
+++ b/tests/dispatcher/test_dispatcher_v2.py
@@ -10,7 +10,7 @@ from iconrpcserver.utils.json_rpc import relay_tx_request
 from tests.dispatcher.conftest import TestDispatcher, REQUESTS_V2, TX_RESULT_HASH
 
 if TYPE_CHECKING:
-    from aiohttp import ClientResponse
+    from httpx import Response
 
 
 @pytest.mark.asyncio
@@ -26,8 +26,8 @@ class TestVersion2Dispatcher(TestDispatcher):
 
         # When I call dispatch method
         # json_response: dict = await Version2Dispatcher.icx_sendTransaction(**json_request)
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
         result = result_json.get('result')
 
         # Then I should receive response code and tx hash as dict type
@@ -48,7 +48,7 @@ class TestVersion2Dispatcher(TestDispatcher):
         mock_channel_tx_creator(response_code=message_code.Response.fail_no_permission)
 
         # When I call dispatch method
-        response: 'ClientResponse' = await test_cli.post(self.URI, json=json_request)
+        response: Response = await test_cli.post(self.URI, json=json_request)
 
         # Then the server should relay tx to another node
         mock_relay_tx_request.assert_called()
@@ -60,8 +60,8 @@ class TestVersion2Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -73,8 +73,8 @@ class TestVersion2Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -85,8 +85,8 @@ class TestVersion2Dispatcher(TestDispatcher):
         json_request = copy.deepcopy(self.REQUESTS["icx_getBalance"])
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -96,8 +96,8 @@ class TestVersion2Dispatcher(TestDispatcher):
         json_request_batch = copy.deepcopy(self.REQUESTS["icx_getBalance_batch"])
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -110,8 +110,8 @@ class TestVersion2Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -123,8 +123,8 @@ class TestVersion2Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -137,8 +137,8 @@ class TestVersion2Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -150,8 +150,8 @@ class TestVersion2Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -164,8 +164,8 @@ class TestVersion2Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"

--- a/tests/dispatcher/test_dispatcher_v3.py
+++ b/tests/dispatcher/test_dispatcher_v3.py
@@ -10,7 +10,7 @@ from iconrpcserver.utils.json_rpc import relay_tx_request
 from tests.dispatcher.conftest import TestDispatcher, REQUESTS_V3
 
 if TYPE_CHECKING:
-    from aiohttp import ClientResponse
+    from httpx import Response
 
 
 @pytest.mark.asyncio
@@ -25,8 +25,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel_tx_creator(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
         tx_hash = result_json.get("result")
 
         # Then I should receive valid tx_hash
@@ -46,7 +46,7 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel_tx_creator(response_code=message_code.Response.fail_no_permission)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
+        response: Response = await test_cli.post(self.URI, json=json_request)
 
         # Then the server should relay tx to another node
         mock_relay_tx_request.assert_called()
@@ -58,8 +58,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -71,8 +71,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -85,8 +85,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -98,8 +98,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -111,8 +111,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -125,8 +125,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -138,8 +138,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -150,8 +150,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         json_request = copy.deepcopy(self.REQUESTS["icx_call"])
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -161,8 +161,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         json_request_batch = copy.deepcopy(self.REQUESTS["icx_call_batch"])
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -173,8 +173,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         json_request = copy.deepcopy(self.REQUESTS["icx_getBalance"])
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -184,8 +184,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         json_request_batch = copy.deepcopy(self.REQUESTS["icx_getBalance_batch"])
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -196,8 +196,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         json_request = copy.deepcopy(self.REQUESTS["icx_getScoreApi"])
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -207,8 +207,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         json_request_batch = copy.deepcopy(self.REQUESTS["icx_getScoreApi_batch"])
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -219,8 +219,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         json_request = copy.deepcopy(self.REQUESTS["icx_getTotalSupply"])
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -232,8 +232,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -245,8 +245,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -259,8 +259,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -272,8 +272,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -286,8 +286,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -299,8 +299,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -313,8 +313,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -326,8 +326,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -340,8 +340,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -353,8 +353,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -367,8 +367,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -380,8 +380,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -394,8 +394,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -407,8 +407,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -421,8 +421,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -434,8 +434,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -447,8 +447,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:
@@ -461,8 +461,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request)
-        result_json: dict = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request)
+        result_json: dict = response.json()
 
         # Then response is not error
         assert 'error' not in result_json, f"request = {json_request}"
@@ -474,8 +474,8 @@ class TestVersion3Dispatcher(TestDispatcher):
         mock_channel(response_code=message_code.Response.success)
 
         # When I call dispatch method
-        response: ClientResponse = await test_cli.post(self.URI, json=json_request_batch)
-        result_json: list = await response.json()
+        response: Response = await test_cli.post(self.URI, json=json_request_batch)
+        result_json: list = response.json()
 
         # Then response is not error
         for json_data in result_json:


### PR DESCRIPTION
 - upgrade sanic to support wesockets >= 9.1
 - upgrade sanic-cors to version 1.0.0
 - fixed deprecated `Request.raw_args` property
 - aiohttp<=3.7.4